### PR TITLE
Backend: Remove all generic cast in event

### DIFF
--- a/src/Application.ts
+++ b/src/Application.ts
@@ -88,7 +88,7 @@ export default class Application extends TypedEmitter<ApplicationEvents> {
         this.logger.debug("Informing instances of each other")
 
         for (let instance of this.instances) {
-            this.emit("selfBroadcast", <InstanceSelfBroadcast>{
+            this.emit("selfBroadcast", {
                 instanceName: instance.instanceName,
                 location: instance.location
             })

--- a/src/ClusterHelper.ts
+++ b/src/ClusterHelper.ts
@@ -1,5 +1,5 @@
 import Application from "./Application"
-import {MinecraftSelfBroadcast, MinecraftSendChat} from "./common/ApplicationEvent"
+import {MinecraftSelfBroadcast} from "./common/ApplicationEvent"
 import {LOCATION} from "./common/ClientInstance"
 
 export default class ClusterHelper {
@@ -16,14 +16,14 @@ export default class ClusterHelper {
     }
 
     sendCommandToMinecraft(instanceName: string, command: string): void {
-        this.app.emit("minecraftSend", <MinecraftSendChat>{
+        this.app.emit("minecraftSend", {
             targetInstanceName: instanceName,
             command: command
         })
     }
 
     sendCommandToAllMinecraft(command: string): void {
-        this.app.emit("minecraftSend", <MinecraftSendChat>{
+        this.app.emit("minecraftSend", {
             targetInstanceName: undefined,
             command: command
         })

--- a/src/instance/discord/ChatManager.ts
+++ b/src/instance/discord/ChatManager.ts
@@ -1,5 +1,4 @@
 import {Message} from "discord.js"
-import {ChatEvent} from "../../common/ApplicationEvent"
 import EventHandler from "../../common/EventHandler"
 import {LOCATION, SCOPE} from "../../common/ClientInstance"
 import DiscordInstance from "./DiscordInstance"
@@ -39,7 +38,7 @@ export default class ChatManager extends EventHandler<DiscordInstance> {
             if (await this.hasBeenMuted(event)) return
             let filteredMessage = await this.proceedFiltering(event, content)
 
-            this.clientInstance.app.emit("chat", <ChatEvent>{
+            this.clientInstance.app.emit("chat", {
                 instanceName: this.clientInstance.instanceName,
                 location: LOCATION.DISCORD,
                 scope: SCOPE.PUBLIC,
@@ -51,7 +50,7 @@ export default class ChatManager extends EventHandler<DiscordInstance> {
         }
 
         if (this.clientInstance.officerChannels.some(id => id === event.channel.id)) {
-            this.clientInstance.app.emit("chat", <ChatEvent>{
+            this.clientInstance.app.emit("chat", {
                 instanceName: this.clientInstance.instanceName,
                 location: LOCATION.DISCORD,
                 scope: SCOPE.OFFICER,

--- a/src/instance/discord/CommandManager.ts
+++ b/src/instance/discord/CommandManager.ts
@@ -8,7 +8,6 @@ import {
 
 import EventHandler from "../../common/EventHandler"
 import {LOCATION, SCOPE} from "../../common/ClientInstance"
-import {CommandEvent} from "../../common/ApplicationEvent"
 import DiscordInstance from "./DiscordInstance"
 import {DiscordCommandInterface, Permission} from "./common/DiscordCommandInterface"
 
@@ -89,12 +88,12 @@ export class CommandManager extends EventHandler<DiscordInstance> {
             } else {
                 this.clientInstance.logger.debug(`execution granted.`)
 
-                this.clientInstance.app.emit("command", <CommandEvent>{
+                this.clientInstance.app.emit("command", {
                     instanceName: this.clientInstance.instanceName,
                     location: LOCATION.DISCORD,
                     scope: SCOPE.PUBLIC,
                     username: (<GuildMember>interaction?.member)?.displayName || interaction.user.username,
-                    fullCommand: interaction.command?.options.toString(),
+                    fullCommand: interaction.command?.options.toString() || "",
                     commandName: interaction.commandName,
                 })
 

--- a/src/instance/discord/commands/RestartCommand.ts
+++ b/src/instance/discord/commands/RestartCommand.ts
@@ -1,7 +1,6 @@
 import {CommandInteraction, SlashCommandBuilder} from "discord.js"
 import {DiscordCommandInterface, Permission} from "../common/DiscordCommandInterface"
 import DiscordInstance from "../DiscordInstance"
-import {InstanceRestartSignal} from "../../../common/ApplicationEvent"
 
 export default <DiscordCommandInterface>{
     commandBuilder: new SlashCommandBuilder()
@@ -15,7 +14,7 @@ export default <DiscordCommandInterface>{
 
         // @ts-ignore
         let targetInstance: string | undefined = interaction.options.getString("instance")
-        clientInstance.app.emit("restartSignal", <InstanceRestartSignal>{
+        clientInstance.app.emit("restartSignal", {
             targetInstanceName: targetInstance
         })
         await interaction.editReply(`Restart signal has been sent!`)

--- a/src/instance/globalChat/GlobalChatInstance.ts
+++ b/src/instance/globalChat/GlobalChatInstance.ts
@@ -58,7 +58,7 @@ export default class GlobalChatInstance extends ClientInstance {
             return
         }
 
-        this.app.emit("chat", <ChatEvent>{
+        this.app.emit("chat", {
             instanceName: this.instanceName,
             location: LOCATION.GLOBAL,
             scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/CommandsManager.ts
+++ b/src/instance/minecraft/CommandsManager.ts
@@ -1,6 +1,5 @@
 import fs = require("fs")
 import MinecraftInstance from "./MinecraftInstance"
-import {ClientEvent, CommandEvent} from "../../common/ApplicationEvent"
 import {LOCATION, SCOPE} from "../../common/ClientInstance"
 
 const COLOR = require('../../../config/discord-config.json').events.color
@@ -36,7 +35,7 @@ export async function publicCommandHandler(minecraftInstance: MinecraftInstance,
     let command = commands.find(c => c.triggers.some((t: string) => t === commandName))
     if (!command || command.disabled) return false
 
-    minecraftInstance.app.emit("command", <CommandEvent>{
+    minecraftInstance.app.emit("command", {
         instanceName: minecraftInstance.instanceName,
         location: LOCATION.MINECRAFT,
         scope: SCOPE.PUBLIC,
@@ -48,7 +47,7 @@ export async function publicCommandHandler(minecraftInstance: MinecraftInstance,
     let reply = await command.handler(minecraftInstance, username, args)
     await minecraftInstance.send(`/gc ${reply}`)
 
-    minecraftInstance.app.emit("event", <ClientEvent>{
+    minecraftInstance.app.emit("event", {
         instanceName: minecraftInstance.instanceName,
         location: LOCATION.MINECRAFT,
         scope: SCOPE.PUBLIC,
@@ -67,7 +66,7 @@ export async function privateCommandHandler(minecraftInstance: MinecraftInstance
 
     minecraftInstance.logger.debug(`${username} executed from private chat: ${message}`)
 
-    minecraftInstance.app.emit("command", <CommandEvent>{
+    minecraftInstance.app.emit("command", {
         instanceName: minecraftInstance.instanceName,
         location: LOCATION.MINECRAFT,
         scope: SCOPE.PRIVATE,

--- a/src/instance/minecraft/MinecraftInstance.ts
+++ b/src/instance/minecraft/MinecraftInstance.ts
@@ -2,7 +2,7 @@ import MineFlayer = require('mineflayer');
 import ChatManager from "./ChatManager"
 import Application from "../../Application"
 import {ClientInstance, LOCATION, Status} from "../../common/ClientInstance"
-import {ChatEvent, ClientEvent, InstanceEvent, InstanceEventType} from "../../common/ApplicationEvent"
+import {ChatEvent, ClientEvent, InstanceEventType} from "../../common/ApplicationEvent"
 import RawChatHandler from "./handlers/RawChatHandler";
 import SelfBroadcastHandler from "./handlers/SelfBroadcastHandler";
 import SendChatHandler from "./handlers/SendChatHandler";
@@ -74,7 +74,7 @@ export default class MinecraftInstance extends ClientInstance {
         if (this.client) this.client.quit()
 
         this.client = MineFlayer.createBot(<any>this.connectionOptions)
-        this.app.emit("instance", <InstanceEvent>{
+        this.app.emit("instance", {
             instanceName: this.instanceName,
             location: LOCATION.MINECRAFT,
             type: InstanceEventType.create,

--- a/src/instance/minecraft/chat/BlockChat.ts
+++ b/src/instance/minecraft/chat/BlockChat.ts
@@ -3,7 +3,6 @@
 import MinecraftInstance from "../MinecraftInstance"
 import {LOCATION, SCOPE} from "../../../common/ClientInstance"
 import {MinecraftChatMessage} from "../common/ChatInterface"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 
 const COLOR = require('../../../../config/discord-config.json').events.color
 
@@ -14,7 +13,7 @@ export default <MinecraftChatMessage>{
         let match = regex.exec(message)
         if (match != null) {
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/DemoteChat.ts
+++ b/src/instance/minecraft/chat/DemoteChat.ts
@@ -1,4 +1,3 @@
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import MinecraftInstance from "../MinecraftInstance"
 import {MinecraftChatMessage} from "../common/ChatInterface"
 import {LOCATION} from "../../../common/ClientInstance"
@@ -14,7 +13,7 @@ export default <MinecraftChatMessage>{
         if (match != null) {
             let username = match[1]
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/JoinChat.ts
+++ b/src/instance/minecraft/chat/JoinChat.ts
@@ -1,5 +1,4 @@
 import MinecraftInstance from "../MinecraftInstance"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {MinecraftChatMessage} from "../common/ChatInterface"
 import {LOCATION} from "../../../common/ClientInstance"
 
@@ -14,7 +13,7 @@ export default <MinecraftChatMessage>{
         if (match != null) {
             let username = match[1]
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/KickChat.ts
+++ b/src/instance/minecraft/chat/KickChat.ts
@@ -1,5 +1,4 @@
 import MinecraftInstance from "../MinecraftInstance"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {MinecraftChatMessage} from "../common/ChatInterface"
 import {LOCATION} from "../../../common/ClientInstance"
 
@@ -14,7 +13,7 @@ export default <MinecraftChatMessage>{
         if (match != null) {
             let username = match[1]
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/LeaveChat.ts
+++ b/src/instance/minecraft/chat/LeaveChat.ts
@@ -1,4 +1,3 @@
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {MinecraftChatMessage} from "../common/ChatInterface"
 import MinecraftInstance from "../MinecraftInstance"
 import {LOCATION} from "../../../common/ClientInstance"
@@ -14,7 +13,7 @@ export default <MinecraftChatMessage>{
         if (match != null) {
             let username = match[1]
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/MuteChat.ts
+++ b/src/instance/minecraft/chat/MuteChat.ts
@@ -1,5 +1,4 @@
 import MinecraftInstance from "../MinecraftInstance"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {LOCATION} from "../../../common/ClientInstance"
 import {MinecraftChatMessage} from "../common/ChatInterface";
 import {SCOPE} from "../../../common/ClientInstance";
@@ -19,7 +18,7 @@ export default <MinecraftChatMessage>{
 
             clientInstance.app.punishedUsers.mute(username, muteTime * sufficeToTime(muteSuffice))
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.OFFICER,

--- a/src/instance/minecraft/chat/OfficerChat.ts
+++ b/src/instance/minecraft/chat/OfficerChat.ts
@@ -1,7 +1,6 @@
-import {ChatEvent} from "../../../common/ApplicationEvent"
 import MinecraftInstance from "../MinecraftInstance"
 import {MinecraftChatMessage} from "../common/ChatInterface"
-import {LOCATION,SCOPE} from "../../../common/ClientInstance"
+import {LOCATION, SCOPE} from "../../../common/ClientInstance"
 
 const {bridge_prefix} = require("../../../../config/minecraft-config.json")
 
@@ -18,7 +17,7 @@ export default <MinecraftChatMessage>{
             if (bridge_prefix && playerMessage.startsWith(bridge_prefix)) return
             if (clientInstance.app.clusterHelper.isMinecraftBot(username)) return
 
-            clientInstance.app.emit("chat", <ChatEvent>{
+            clientInstance.app.emit("chat", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.OFFICER,

--- a/src/instance/minecraft/chat/OfflineChat.ts
+++ b/src/instance/minecraft/chat/OfflineChat.ts
@@ -1,5 +1,4 @@
 import MinecraftInstance from "../MinecraftInstance"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {LOCATION, SCOPE} from "../../../common/ClientInstance"
 import {MinecraftChatMessage} from "../common/ChatInterface";
 
@@ -13,7 +12,7 @@ export default <MinecraftChatMessage>{
         if (match != null) {
             let username = match[1]
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/OnlineChat.ts
+++ b/src/instance/minecraft/chat/OnlineChat.ts
@@ -1,5 +1,4 @@
 import MinecraftInstance from "../MinecraftInstance"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {MinecraftChatMessage} from "../common/ChatInterface"
 import {LOCATION} from "../../../common/ClientInstance"
 
@@ -15,7 +14,7 @@ export default <MinecraftChatMessage>{
         if (match != null) {
             let username = match[1]
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/PromoteChat.ts
+++ b/src/instance/minecraft/chat/PromoteChat.ts
@@ -1,6 +1,5 @@
 import {LOCATION, SCOPE} from "../../../common/ClientInstance"
 import MinecraftInstance from "../MinecraftInstance"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {MinecraftChatMessage} from "../common/ChatInterface"
 
 const COLOR = require('../../../../config/discord-config.json').events.color
@@ -13,7 +12,7 @@ export default <MinecraftChatMessage>{
         if (match != null) {
             let username = match[1]
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/PublicChat.ts
+++ b/src/instance/minecraft/chat/PublicChat.ts
@@ -1,5 +1,4 @@
 import MinecraftInstance from "../MinecraftInstance"
-import {ChatEvent} from "../../../common/ApplicationEvent"
 import {publicCommandHandler} from '../CommandsManager'
 import {LOCATION, SCOPE} from "../../../common/ClientInstance"
 import {MinecraftChatMessage} from "../common/ChatInterface"
@@ -21,7 +20,7 @@ export default <MinecraftChatMessage>{
             if (clientInstance.app.clusterHelper.isMinecraftBot(username)) return
             if (await publicCommandHandler(clientInstance, username, playerMessage)) return
 
-            clientInstance.app.emit("chat", <ChatEvent>{
+            clientInstance.app.emit("chat", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/RepeatChat.ts
+++ b/src/instance/minecraft/chat/RepeatChat.ts
@@ -1,6 +1,5 @@
 import {LOCATION, SCOPE} from "../../../common/ClientInstance"
 import MinecraftInstance from "../MinecraftInstance"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {MinecraftChatMessage} from "../common/ChatInterface"
 
 const COLOR = require('../../../../config/discord-config.json').events.color
@@ -32,7 +31,7 @@ export default <MinecraftChatMessage>{
         if (match != null) {
             let randomMessage = MESSAGES[Math.floor(Math.random() * MESSAGES.length)]
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.PUBLIC,

--- a/src/instance/minecraft/chat/UnmuteChat.ts
+++ b/src/instance/minecraft/chat/UnmuteChat.ts
@@ -1,5 +1,4 @@
 import MinecraftInstance from "../MinecraftInstance"
-import {ClientEvent} from "../../../common/ApplicationEvent"
 import {MinecraftChatMessage} from "../common/ChatInterface"
 import {LOCATION} from "../../../common/ClientInstance"
 
@@ -17,7 +16,7 @@ export default <MinecraftChatMessage>{
 
             clientInstance.app.punishedUsers.unmute(username)
 
-            clientInstance.app.emit("event", <ClientEvent>{
+            clientInstance.app.emit("event", {
                 instanceName: clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 scope: SCOPE.OFFICER,

--- a/src/instance/minecraft/handlers/RawChatHandler.ts
+++ b/src/instance/minecraft/handlers/RawChatHandler.ts
@@ -1,7 +1,6 @@
 import EventHandler from '../../../common/EventHandler'
 import MinecraftInstance from "../MinecraftInstance"
 import {ChatMessage} from "prismarine-chat"
-import {MinecraftRawChatEvent} from "../../../common/ApplicationEvent"
 import {LOCATION} from "../../../common/ClientInstance"
 
 export default class RawChatHandler extends EventHandler<MinecraftInstance> {
@@ -15,7 +14,7 @@ export default class RawChatHandler extends EventHandler<MinecraftInstance> {
     }
 
     private onRawMessage(message: string) {
-        this.clientInstance.app.emit("minecraftChat", <MinecraftRawChatEvent>{
+        this.clientInstance.app.emit("minecraftChat", {
             instanceName: this.clientInstance.instanceName,
             location: LOCATION.MINECRAFT,
             message: message

--- a/src/instance/minecraft/handlers/SelfBroadcastHandler.ts
+++ b/src/instance/minecraft/handlers/SelfBroadcastHandler.ts
@@ -1,6 +1,5 @@
 import EventHandler from '../../../common/EventHandler'
 import MinecraftInstance from "../MinecraftInstance"
-import {MinecraftSelfBroadcast} from "../../../common/ApplicationEvent"
 import {LOCATION} from "../../../common/ClientInstance"
 
 export default class SelfBroadcastHandler extends EventHandler<MinecraftInstance> {
@@ -18,7 +17,7 @@ export default class SelfBroadcastHandler extends EventHandler<MinecraftInstance
         let uuid = this.clientInstance.uuid()
 
         if (username && uuid) {
-            this.clientInstance.app.emit("minecraftSelfBroadcast", <MinecraftSelfBroadcast>{
+            this.clientInstance.app.emit("minecraftSelfBroadcast", {
                 instanceName: this.clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 uuid: uuid,

--- a/src/instance/minecraft/handlers/StateHandler.ts
+++ b/src/instance/minecraft/handlers/StateHandler.ts
@@ -1,6 +1,6 @@
 import EventHandler from '../../../common/EventHandler'
 import MinecraftInstance from "../MinecraftInstance"
-import {InstanceEvent, InstanceEventType} from "../../../common/ApplicationEvent"
+import {InstanceEventType} from "../../../common/ApplicationEvent"
 import {LOCATION, Status} from "../../../common/ClientInstance"
 
 export default class StateHandler extends EventHandler<MinecraftInstance> {
@@ -27,7 +27,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
         this.exactDelay = 0
         this.clientInstance.status = Status.CONNECTED
 
-        this.clientInstance.app.emit("instance", <InstanceEvent>{
+        this.clientInstance.app.emit("instance", {
             instanceName: this.clientInstance.instanceName,
             location: LOCATION.MINECRAFT,
             type: InstanceEventType.connect,
@@ -40,7 +40,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
             let reason = `Status is ${this.clientInstance.status}. no further retrying to reconnect.`
 
             this.clientInstance.logger.warn(reason)
-            this.clientInstance.app.emit("instance", <InstanceEvent>{
+            this.clientInstance.app.emit("instance", {
                 instanceName: this.clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 type: InstanceEventType.end,
@@ -52,7 +52,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
             let reason = `Client quit on its own volition. no further retrying to reconnect.`
 
             this.clientInstance.logger.debug(reason)
-            this.clientInstance.app.emit("instance", <InstanceEvent>{
+            this.clientInstance.app.emit("instance", {
                 instanceName: this.clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 type: InstanceEventType.end,
@@ -73,7 +73,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
         this.clientInstance.logger.error(`Minecraft bot disconnected from server,`
             + `attempting reconnect in ${loginDelay / 1000} seconds`)
 
-        this.clientInstance.app.emit("instance", <InstanceEvent>{
+        this.clientInstance.app.emit("instance", {
             instanceName: this.clientInstance.instanceName,
             location: LOCATION.MINECRAFT,
             type: InstanceEventType.disconnect,
@@ -94,7 +94,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
             this.clientInstance.logger.fatal("Instance will shut off since someone logged in from another place")
             this.clientInstance.status = Status.FAILED
 
-            this.clientInstance.app.emit("instance", <InstanceEvent>{
+            this.clientInstance.app.emit("instance", {
                 instanceName: this.clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 type: InstanceEventType.conflict,
@@ -104,7 +104,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
             })
 
         } else {
-            this.clientInstance.app.emit("instance", <InstanceEvent>{
+            this.clientInstance.app.emit("instance", {
                 instanceName: this.clientInstance.instanceName,
                 location: LOCATION.MINECRAFT,
                 type: InstanceEventType.kick,

--- a/src/instance/webhook/WebhookInstance.ts
+++ b/src/instance/webhook/WebhookInstance.ts
@@ -49,7 +49,7 @@ export default class WebhookInstance extends ClientInstance {
             return
         }
 
-        this.app.emit("chat", <ChatEvent>{
+        this.app.emit("chat", {
             instanceName: this.instanceName,
             location: LOCATION.WEBHOOK,
             scope: SCOPE.PUBLIC,


### PR DESCRIPTION
Casting the object to the event will remove all warnings to missing fields, which could introduce bugs.