### PR TITLE
bugfix: Welcome message sent multiple times if application running in cluster mode

### DIFF
--- a/src/plugins/WelcomePlugin.ts
+++ b/src/plugins/WelcomePlugin.ts
@@ -18,6 +18,7 @@ export default <PluginInterface>{
     onRun(app: Application, getLocalInstance: (instanceName: string) => ClientInstance<any> | undefined): any {
         app.on("event", event => {
             if (event.name !== "join") return
+            if (!app.config.plugins.allowSocketInstance && !getLocalInstance(event.instanceName)) return
 
             let message = MESSAGES[Math.floor(Math.random() * MESSAGES.length)]
             message = message.replaceAll("%s", <string>event.username)


### PR DESCRIPTION
each node could have the same plugin enabled. An event sent to all nodes will result in the event being processed multiple times