### PR TITLE
fix #31 Blocked message event repeats itself nonstop

### DIFF
--- a/src/instance/minecraft/MinecraftInstance.ts
+++ b/src/instance/minecraft/MinecraftInstance.ts
@@ -59,6 +59,7 @@ export default class MinecraftInstance extends ClientInstance<MinecraftConfig> {
             if (event.scope !== SCOPE.PUBLIC) return
             if (event.removeLater) return
             if (event.name === EventType.COMMAND) return
+            if (event.name === EventType.BLOCK) return
 
             return this.send(`/gc @[${event.instanceName || "Main"}]: ${event.message}`)
         })


### PR DESCRIPTION
Discord have less strict language control by default and isn't as moderated as Minecraft servers. 
Minecraft instance doesn't need to broadcast blocked messages to begin with. 
They are only needed for discord instance to warn users about their language. 
If a message will be blocked by a minecraft instance, then another minecraft instance can not possibly send that message to begin with. Hence, blocking it completely is an optimal fix.