### PR TITLE
Blur blocked message text and fixes #36

### DIFF
--- a/src/instance/minecraft/chat/BlockChat.ts
+++ b/src/instance/minecraft/chat/BlockChat.ts
@@ -23,7 +23,7 @@ export default <MinecraftChatMessage>{
                 name: EventType.BLOCK,
                 username: undefined,
                 severity: ColorScheme.INFO,
-                message: message,
+                message: "The message has been blocked by Hypixel for breaking the rules.",
                 removeLater: false
             })
         }


### PR DESCRIPTION
To prevent from having the bot saying slurs and to protect privacy (as a workaround for #36).