### PR TITLE
Prevent repeat block message from being resend to minecraft instances

### DIFF
--- a/src/instance/minecraft/MinecraftInstance.ts
+++ b/src/instance/minecraft/MinecraftInstance.ts
@@ -60,6 +60,7 @@ export default class MinecraftInstance extends ClientInstance<MinecraftConfig> {
             if (event.removeLater) return
             if (event.name === EventType.COMMAND) return
             if (event.name === EventType.BLOCK) return
+            if (event.name === EventType.REPEAT) return
 
             return this.send(`/gc @[${event.instanceName || "Main"}]: ${event.message}`)
         })


### PR DESCRIPTION
Only minecraft chat can create this event, looping the event back to them will create an endless loop.