### PR TITLE
Drop 8 years old mojang library and create basic api that supports typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "hypixel-api-reborn": "^10.0.0",
     "log4js": "^6.4.2",
     "mineflayer": "4.3.0",
-    "mojang": "^2.2.2",
     "moment": "^2.29.4",
     "node-cache": "^5.1.2",
     "prismarine-chat": "^1.9.1",

--- a/src/Application.ts
+++ b/src/Application.ts
@@ -28,6 +28,7 @@ import { getLogger, Logger } from 'log4js'
 import { ApplicationConfig } from './ApplicationConfig'
 import SocketInstance from './instance/socket/SocketInstance'
 import * as path from 'path'
+import { MojangApi } from './util/Mojang'
 
 export default class Application extends TypedEmitter<ApplicationEvents> {
   private readonly logger: Logger
@@ -37,6 +38,7 @@ export default class Application extends TypedEmitter<ApplicationEvents> {
   readonly clusterHelper: ClusterHelper
   readonly punishedUsers: PunishedUsers
   readonly hypixelApi: HypixelClient
+  readonly mojangApi: MojangApi
   readonly config: ApplicationConfig
 
   constructor(config: ApplicationConfig) {
@@ -50,6 +52,7 @@ export default class Application extends TypedEmitter<ApplicationEvents> {
       cache: true,
       cacheTime: 300
     })
+    this.mojangApi = new MojangApi()
     this.punishedUsers = new PunishedUsers()
     this.clusterHelper = new ClusterHelper(this)
 

--- a/src/instance/minecraft/commands/CataCommand.ts
+++ b/src/instance/minecraft/commands/CataCommand.ts
@@ -2,15 +2,16 @@ import MinecraftInstance from '../MinecraftInstance'
 import { MinecraftCommandMessage } from '../common/ChatInterface'
 import { Client, SkyblockMember } from 'hypixel-api-reborn'
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const Mojang = require('mojang')
-
 export default {
   triggers: ['catacomb', 'cata'],
   enabled: true,
   handler: async function (clientInstance: MinecraftInstance, username: string, args: string[]): Promise<string> {
-    const givenUsername = args[0] != null ? args[0] : username
-    const uuid = await Mojang.lookupProfileAt(givenUsername).then((mojangProfile: { id: any }) => mojangProfile.id)
+    const givenUsername = args[0] ?? username
+
+    const uuid = await clientInstance.app.mojangApi
+      .profileByUsername(givenUsername)
+      .then((mojangProfile) => mojangProfile.id)
+      .catch(() => null)
 
     if (uuid == null) {
       return `No such username! (given: ${givenUsername})`

--- a/src/instance/minecraft/commands/GuildCommand.ts
+++ b/src/instance/minecraft/commands/GuildCommand.ts
@@ -7,15 +7,16 @@
 import MinecraftInstance from '../MinecraftInstance'
 import { MinecraftCommandMessage } from '../common/ChatInterface'
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const mojang = require('mojang')
-
 export default {
   triggers: ['guild', 'guildOf', 'g'],
   enabled: true,
   handler: async function (clientInstance: MinecraftInstance, username: string, args: string[]): Promise<string> {
-    const givenUsername = args[0] != null ? args[0] : username
-    const uuid = await mojang.lookupProfileAt(givenUsername).then((p: { id: any }) => p.id)
+    const givenUsername = args[0] ?? username
+
+    const uuid = await clientInstance.app.mojangApi
+      .profileByUsername(givenUsername)
+      .then((p) => p.id)
+      .catch(() => null)
 
     if (uuid == null) {
       return `No such username! (given: ${givenUsername})`

--- a/src/instance/minecraft/commands/LevelCommand.ts
+++ b/src/instance/minecraft/commands/LevelCommand.ts
@@ -1,15 +1,16 @@
 import MinecraftInstance from '../MinecraftInstance'
 import { MinecraftCommandMessage } from '../common/ChatInterface'
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const Mojang = require('mojang')
-
 export default {
   triggers: ['level', 'lvl', 'l'],
   enabled: true,
   handler: async function (clientInstance: MinecraftInstance, username: string, args: string[]): Promise<string> {
-    const givenUsername = args[0] != null ? args[0] : username
-    const uuid = await Mojang.lookupProfileAt(givenUsername).then((mojangProfile: { id: any }) => mojangProfile.id)
+    const givenUsername = args[0] ?? username
+
+    const uuid = await clientInstance.app.mojangApi
+      .profileByUsername(givenUsername)
+      .then((p) => p.id)
+      .catch(() => null)
 
     if (uuid == null) {
       return `No such username! (given: ${givenUsername})`

--- a/src/instance/minecraft/commands/NetworthCommand.ts
+++ b/src/instance/minecraft/commands/NetworthCommand.ts
@@ -7,16 +7,18 @@ import MinecraftInstance from '../MinecraftInstance'
 import { MinecraftCommandMessage } from '../common/ChatInterface'
 
 import { getNetworth, localizedNetworth } from '../../../util/SkyblockApi'
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const Mojang = require('mojang')
+import { HypixelSkyblock } from '../../../type/HypixelType'
 
 export default {
   triggers: ['networth', 'net', 'nw'],
   enabled: true,
   handler: async function (clientInstance: MinecraftInstance, username: string, args: string[]): Promise<string> {
-    const givenUsername = args[0] != null ? args[0] : username
-    const uuid = await Mojang.lookupProfileAt(givenUsername).then((mojangProfile: { id: any }) => mojangProfile.id)
+    const givenUsername = args[0] ?? username
+
+    const uuid = await clientInstance.app.mojangApi
+      .profileByUsername(givenUsername)
+      .then((mojangProfile) => mojangProfile.id)
+      .catch(() => null)
 
     if (uuid == null) {
       return `No such username! (given: ${givenUsername})`

--- a/src/util/Mojang.ts
+++ b/src/util/Mojang.ts
@@ -1,0 +1,26 @@
+import Axios from 'axios'
+
+export class MojangApi {
+  async profileByUsername(username: string): Promise<MojangProfile> {
+    return await Axios.get(`https://api.mojang.com/users/profiles/minecraft/${username}`).then(
+      (res) => res.data as MojangProfile
+    )
+  }
+
+  async profileByUuid(uuid: string): Promise<MojangProfile> {
+    return await Axios.get(`https://sessionserver.mojang.com/session/minecraft/profile/${uuid}`).then(
+      (res) => res.data as MojangProfile
+    )
+  }
+
+  async profilesByUsername(usernames: string[]): Promise<MojangProfile[]> {
+    return await Axios.post(`https://api.mojang.com/profiles/minecraft`, usernames).then(
+      (res) => res.data as MojangProfile[]
+    )
+  }
+}
+
+export interface MojangProfile {
+  id: string
+  name: string
+}


### PR DESCRIPTION
The old mojang library is coded in javascript and doesn't have any documentation that can be used for typescript and linters.