### PR TITLE
Remove old test loading packages.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,14 +7,7 @@ import Application from './src/Application'
 console.log('Loading Logger...')
 const logger = configure(logConfig).getLogger('Main')
 
-logger.debug('Test loading all libraries...')
-
-for (const dependency in packageJson.dependencies) {
-  logger.trace(`Test-loading ${dependency}...`)
-  require(dependency)
-}
-
-logger.debug('Loading modules and setting up process...')
+logger.debug('Setting up process...')
 process.on('uncaughtException', function (e) {
   logger.fatal(e)
   process.exitCode = 1
@@ -24,6 +17,7 @@ process.title = packageJson.name
 
 if (process.argv.includes('test-run')) {
   logger.warn('Argument passed to run in testing mode')
+  logger.warn('Test Loading finished.')
   logger.warn('Returning from program with exit code 0')
   process.exit(0)
 }


### PR DESCRIPTION
Used to be useful when dynamic loading was used. Now, everything's preloaded and compiled.