### PR TITLE
remove all non ascii characters when reading for a discord username

### DIFF
--- a/src/util/DiscordMessageUtil.ts
+++ b/src/util/DiscordMessageUtil.ts
@@ -58,6 +58,10 @@ export const getReplyUsername = async function (messageEvent: Message): Promise<
 }
 
 export const getReadableName = function (username: string, id: string): string {
+  // clear all non ASCII characters
+  // eslint-disable-next-line no-control-regex
+  username = username.replace(/[^\x00-\x7F]/g, '')
+
   username = username.trim().slice(0, 16)
 
   if (/^\w+$/.test(username)) return username


### PR DESCRIPTION
![image](https://github.com/aidn3/hypixel-guild-discord-bridge/assets/24919899/ac4b3c8c-a24a-4d38-9ceb-432267bfa9b9)

This is to fix an issue with non ascii characters. The validation process checks the first 16 letters and if they are invalid, the discord id will be used instead.

This update aims to fix that by first removing all non ascii characters then checking for a proper username after.