### PR TITLE
Add custom auth flow support

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -30,6 +30,26 @@ minecraft:
     - instanceName: 'Good-Name'
       email: 'email@example.com'
       password: 'password1234'
+      # ---------------------------------
+      # Advanced Login Method
+      # ---------------------------------
+      # When using this `email` and `password` CAN be commented out (although it is not necessary)
+      # Whether to enable custom auth, when enabled the `email` and `password` fields will be completely ignored
+      # and below credentials will instead be used to obtain a session (from cache).
+      #useCustomAuth: true
+      # Identifier for this account, only used to determine the session cache file name. (Cache folder is at ~/.minecraft/hypixel-guild-discord-bridge-cache)
+      # I recommend you set this to a username, uuid or email address. You're free to put whatever you want here though.
+      #identifier: 'Notch'
+      # Your Microsoft Azure PUBLIC clientId (application id)
+      #clientId: 'your-dashed-client-uuid'
+      # MUST be specified EXPLICITLY in your Microsoft Azure application;
+      # For the bridge, it doesn't matter what the redirect uri is. It has to be specified for some authentication requests;
+      # No data is ever "redirected" to this URL however.
+      #redirectUri: 'http://localhost:12345/'
+      # https://wiki.vg/Microsoft_Authentication_Scheme#Microsoft_OAuth2_Flow
+      # REQUIRED Scopes are `XboxLive.signin XboxLive.offline_access`
+      #initialRefreshToken: 'Rather Long Microsoft Access Token, obtained as the final step of ANY Microsoft Auth flow.'
+
       # This will be used when initiating connection to minecraft server
       # It will not be used for other purposes.
       # Leave empty or set it to null to disable

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "yaml": "^2.2.2"
   },
   "devDependencies": {
+    "@types/node": "^20.10.6",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "eslint": "^8.49.0",
@@ -53,6 +54,7 @@
     "eslint-plugin-json": "^2.1.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-unicorn": "^48.0.1",
+    "minecraft-protocol": "^1.45.0",
     "prettier": "^3.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"

--- a/src/ApplicationConfig.ts
+++ b/src/ApplicationConfig.ts
@@ -40,9 +40,17 @@ function parseMinecraftInstances(minecraftYaml: any & { instances: any[] }): Min
     }
 
     config.instanceName = instanceYaml.instanceName
-    config.botOptions.auth = 'microsoft'
-    config.botOptions.username = instanceYaml.email
-    config.botOptions.password = instanceYaml.password
+    if (instanceYaml.useCustomAuth) {
+      config.customAuthOptions = {}
+      config.customAuthOptions.identifier = instanceYaml.identifier
+      config.customAuthOptions.clientId = instanceYaml.clientId
+      config.customAuthOptions.redirectUri = instanceYaml.redirectUri
+      config.customAuthOptions.initialRefreshToken = instanceYaml.initialRefreshToken
+    } else {
+      config.botOptions.auth = 'microsoft'
+      config.botOptions.username = instanceYaml.email
+      config.botOptions.password = instanceYaml.password
+    }
 
     if (instanceYaml.proxy != null) {
       const proxyArgs = instanceYaml.proxy.split(':')

--- a/src/common/CacheCustomAuthProvider.ts
+++ b/src/common/CacheCustomAuthProvider.ts
@@ -1,0 +1,244 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import axios from 'axios'
+import { CustomAuthProvider } from '../util/MineFlayerCustomAuth'
+
+interface Cached {
+  username: string
+  uuid: string // Not dashed
+  accessToken: string
+  refreshToken: string
+}
+
+interface Session {
+  username: string
+  uuid: string // Dashed
+  accessToken: string
+}
+
+// TODO Store expiration dates in cache
+export class CacheCustomAuthProvider implements CustomAuthProvider {
+  constructor(
+    private readonly identifier: string /* doesn't have to be anything fancy, just used for determining cache location */,
+    private readonly clientId: string,
+    private readonly redirectUri: string, // Just has to be allowed for your given clientId, isn't actually used anywhere
+    private readonly initialRefreshToken: string
+  ) {}
+
+  private getFolder() {
+    const folder = path.join(os.homedir(), '.minecraft', 'hypixel-guild-discord-bridge-cache')
+    if (!fs.existsSync(folder))
+      fs.mkdirSync(folder, {
+        recursive: true
+      })
+
+    return folder
+  }
+
+  private getFile() {
+    return path.join(this.getFolder(), `${this.identifier}_with_${this.clientId}.json`)
+  }
+
+  private async refreshToken(refreshToken: string) {
+    const response = await axios.post(
+      'https://login.live.com/oauth20_token.srf',
+      new URLSearchParams({
+        client_id: this.clientId,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+        redirect_uri: this.redirectUri
+      })
+    )
+    const data = response.data as {
+      access_token: string
+      refresh_token: string
+    }
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token
+    }
+  }
+
+  private async authXBL(authToken: string) {
+    const response = await axios.post(
+      'https://user.auth.xboxlive.com/user/authenticate',
+      JSON.stringify({
+        Properties: {
+          AuthMethod: 'RPS',
+          SiteName: 'user.auth.xboxlive.com',
+          RpsTicket: `d=${authToken}`
+        },
+        RelyingParty: 'http://auth.xboxlive.com',
+        TokenType: 'JWT'
+      }),
+      {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    const data = response.data as {
+      Token: string
+    }
+
+    return {
+      token: data.Token
+    }
+  }
+
+  private async authXSTS(XBLToken: string) {
+    const response = await axios.post(
+      'https://xsts.auth.xboxlive.com/xsts/authorize',
+      JSON.stringify({
+        Properties: {
+          UserTokens: [XBLToken],
+          SandboxId: 'RETAIL'
+        },
+        RelyingParty: 'rp://api.minecraftservices.com/',
+        TokenType: 'JWT'
+      }),
+      {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    const data = response.data as {
+      Token: string
+      DisplayClaims: {
+        xui: [
+          {
+            uhs: string
+          }
+        ]
+      }
+    }
+
+    return {
+      token: data.Token,
+      uhs: data.DisplayClaims.xui[0].uhs
+    }
+  }
+
+  private async authMinecraft(XSTSToken: string, uhs: string) {
+    const response = await axios.post(
+      'https://api.minecraftservices.com/authentication/login_with_xbox',
+      JSON.stringify({
+        identityToken: `XBL3.0 x=${uhs};${XSTSToken}`
+      }),
+      {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    const data = response.data as {
+      access_token: string
+    }
+
+    return data.access_token
+  }
+
+  private async getProfile(accessToken: string) {
+    const response = await axios.get('https://api.minecraftservices.com/minecraft/profile', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    })
+    const data = response.data as {
+      id: string
+      name: string
+    }
+
+    return {
+      uuid: data.id,
+      username: data.name
+    }
+  }
+
+  private toDashed(uuid: string) {
+    return (
+      uuid.slice(0, 8) +
+      '-' +
+      uuid.slice(8, 12) +
+      '-' +
+      uuid.slice(12, 16) +
+      '-' +
+      uuid.slice(16, 20) +
+      '-' +
+      uuid.slice(20, 32)
+    )
+  }
+
+  // This isn't actually set at runtime, however this is set in pre() which is called before any of the methods that actually use this field
+  private session: Session = undefined as never
+
+  private async newSession(refreshToken: string) {
+    // assume accessToken expired, refresh it
+    const step1 = await this.refreshToken(refreshToken)
+    const step2 = await this.authXBL(step1.accessToken)
+    const step3 = await this.authXSTS(step2.token)
+    const step4 = await this.authMinecraft(step3.token, step3.uhs)
+    const step5 = await this.getProfile(step4)
+
+    this.session = {
+      accessToken: step4,
+      username: step5.username,
+      uuid: this.toDashed(step5.uuid)
+    }
+
+    fs.writeFileSync(
+      this.getFile(),
+      JSON.stringify(
+        {
+          refreshToken: step1.refreshToken,
+          accessToken: step4,
+          username: step5.username,
+          uuid: step5.uuid
+        } as Cached,
+        undefined,
+        2
+      )
+    )
+  }
+
+  async pre(): Promise<void> {
+    if (fs.existsSync(this.getFile())) {
+      const d = JSON.parse(
+        fs.readFileSync(this.getFile(), {
+          encoding: 'utf8'
+        })
+      ) as Cached
+
+      try {
+        const profile = await this.getProfile(d.accessToken)
+        this.session = {
+          accessToken: d.accessToken,
+          username: profile.username,
+          uuid: this.toDashed(profile.uuid)
+        }
+      } catch {
+        await this.newSession(d.refreshToken)
+      }
+    } else {
+      await this.newSession(this.initialRefreshToken)
+    }
+  }
+
+  getAccessToken(): Promise<string> {
+    return Promise.resolve(this.session.accessToken)
+  }
+
+  getUsername(): Promise<string> {
+    return Promise.resolve(this.session.username)
+  }
+
+  getUuid(): Promise<string> {
+    return Promise.resolve(this.session.uuid)
+  }
+}

--- a/src/instance/minecraft/common/MinecraftConfig.ts
+++ b/src/instance/minecraft/common/MinecraftConfig.ts
@@ -13,4 +13,10 @@ export default interface MinecraftConfig {
   // @ts-expect-error "MineFlayer.Client" not exist
   botOptions: { client: MineFlayer.Client } & Partial<MineFlayer.BotOptions>
   proxy: ProxyConfig | null
+  customAuthOptions?: {
+    identifier: string
+    clientId: string
+    redirectUri: string
+    initialRefreshToken: string // This is invalidated immediately after first launch
+  }
 }

--- a/src/instance/minecraft/handlers/ErrorHandler.ts
+++ b/src/instance/minecraft/handlers/ErrorHandler.ts
@@ -15,7 +15,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
         'Minecraft bot disconnected due to internet problems. Restarting client in 30 seconds...'
       )
       setTimeout(() => {
-        this.clientInstance.connect()
+        void this.clientInstance.connect()
       }, 30_000)
     }
   }

--- a/src/instance/minecraft/handlers/StateHandler.ts
+++ b/src/instance/minecraft/handlers/StateHandler.ts
@@ -98,7 +98,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
     })
 
     setTimeout(() => {
-      this.clientInstance.connect()
+      void this.clientInstance.connect()
     }, loginDelay)
     this.clientInstance.status = Status.CONNECTING
   }

--- a/src/util/CryptoUtil.ts
+++ b/src/util/CryptoUtil.ts
@@ -1,0 +1,12 @@
+// From: MineFlayer
+export function MCPubKeyToPem(mcPubKeyBuffer: Buffer) {
+  let pem = '-----BEGIN PUBLIC KEY-----\n'
+  let base64PubKey = mcPubKeyBuffer.toString('base64')
+  const maxLineLength = 65
+  while (base64PubKey.length > 0) {
+    pem += base64PubKey.slice(0, Math.max(0, maxLineLength)) + '\n'
+    base64PubKey = base64PubKey.slice(Math.max(0, maxLineLength))
+  }
+  pem += '-----END PUBLIC KEY-----\n'
+  return pem
+}

--- a/src/util/MCHexDigest.ts
+++ b/src/util/MCHexDigest.ts
@@ -1,0 +1,27 @@
+// From: https://gist.github.com/andrewrk/4425843
+
+export function MCHexDigest(hash: Buffer) {
+  // check for negative hashes
+  const negative = hash.readInt8(0) < 0
+  if (negative) performTwosCompliment(hash)
+  let digest = hash.toString('hex')
+  // trim leading zeroes
+  digest = digest.replaceAll(/^0+/g, '')
+  if (negative) digest = '-' + digest
+  return digest
+}
+
+function performTwosCompliment(buffer: Buffer) {
+  let carry = true
+  let index, newByte, value
+  for (index = buffer.length - 1; index >= 0; --index) {
+    value = buffer.readUInt8(index)
+    newByte = ~value & 0xFF
+    if (carry) {
+      carry = newByte === 0xFF
+      buffer.writeUInt8(newByte + 1, index)
+    } else {
+      buffer.writeUInt8(newByte, index)
+    }
+  }
+}

--- a/src/util/MineFlayerCustomAuth.ts
+++ b/src/util/MineFlayerCustomAuth.ts
@@ -1,0 +1,157 @@
+import * as crypto from 'node:crypto'
+import axios from 'axios'
+import { Bot, createBot } from 'mineflayer'
+import { MCHexDigest } from './MCHexDigest'
+import { MCPubKeyToPem } from './CryptoUtil'
+
+export interface CustomAuthProvider {
+  pre(): Promise<void> // Called before any of the other 3 functions are called
+  getUsername(): Promise<string>
+  getUuid(): Promise<string> // dashed
+  getAccessToken(): Promise<string>
+}
+
+/**
+ * This will not return until we have authenticated with the target server
+ * @param options Mineflayer options
+ * @param auth Any instance of an object that implements CustomAuthProvider
+ */
+export function createCustomAuthBot(options: object, auth: CustomAuthProvider): Promise<Bot> {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises,unicorn/prevent-abbreviations,no-async-promise-executor
+  return new Promise(async (res, rej) => {
+    await auth.pre()
+    const username = await auth.getUsername()
+    const uuid = await auth.getUuid()
+    const accessToken = await auth.getAccessToken()
+
+    const bot = createBot({ ...options, auth: 'offline', username, profilesFolder: '' })
+    bot._client.uuid = uuid
+
+    let serverId: string
+    let serverPublicKey: Buffer
+    let serverVerifyToken: Buffer
+    let globalSharedSecret: Buffer
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const orig_write = bot._client.write
+    /*
+     * This write hook allows us to intercept authentication and encryption. Allowing us to use our own services to do so.
+     * */
+    bot._client.write = (function (orig) {
+      return function () {
+        // eslint-disable-next-line prefer-rest-params
+        const [id] = arguments
+        if (id === 'encryption_begin') {
+          const sharedSecret = crypto.randomBytes(16)
+
+          const hash = crypto
+            .createHash('sha1')
+            .update(Buffer.from(serverId, 'ascii'))
+            .update(sharedSecret)
+            .update(serverPublicKey)
+            .digest()
+          const digest = MCHexDigest(hash)
+
+          axios
+            .post(
+              'https://sessionserver.mojang.com/session/minecraft/join',
+              JSON.stringify({
+                accessToken,
+                selectedProfile: uuid.replaceAll('-', ''),
+                serverId: digest
+              }),
+              {
+                headers: {
+                  'Content-Type': 'application/json'
+                }
+              }
+            )
+            .then((joinResponse) => {
+              if (joinResponse.status === 204) {
+                const pubKey = MCPubKeyToPem(serverPublicKey)
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-expect-error
+                // eslint-disable-next-line prefer-rest-params,unicorn/prefer-reflect-apply
+                orig.apply(this, [
+                  'encryption_begin',
+                  {
+                    sharedSecret: crypto.publicEncrypt(
+                      {
+                        key: pubKey,
+                        padding: crypto.constants.RSA_PKCS1_PADDING
+                      },
+                      sharedSecret
+                    ),
+                    verifyToken: crypto.publicEncrypt(
+                      {
+                        key: pubKey,
+                        padding: crypto.constants.RSA_PKCS1_PADDING
+                      },
+                      serverVerifyToken
+                    )
+                  }
+                ])
+                globalSharedSecret = sharedSecret
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-expect-error
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                bot._client.setEncryption(sharedSecret)
+
+                // We have successfully completed auth, now we can return the bot instance
+                res(bot)
+              } else {
+                rej(new Error('Failed to join server (auth stage): invalid response code ' + joinResponse.status))
+              }
+            })
+            .catch((error) => {
+              rej(new Error('Failed to join server (auth stage): ' + error))
+            })
+
+          // Return value is always undefined either way
+        } else {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          // eslint-disable-next-line prefer-rest-params,unicorn/prefer-reflect-apply
+          orig.apply(this, arguments)
+          // Return value is always undefined either way
+        }
+      }
+    })(orig_write)
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const orig_setEncryption = bot._client.setEncryption
+    /**
+     * This hook allows us to set our own (the correct) encryption keys on our Mineflayer instance,
+     * instead of the ones which are automatically generated. These don't work as Mineflayer isn't in control of the auth.
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    bot._client.setEncryption = (function (orig) {
+      return function () {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (globalSharedSecret && !bot._client.cipher) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          // eslint-disable-next-line prefer-rest-params,unicorn/prefer-reflect-apply,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+          orig.apply(this, arguments)
+          // Return value is always undefined either way
+        }
+      }
+    })(orig_setEncryption)
+
+    bot._client.on('packet', (data, meta) => {
+      if (meta.name === 'encryption_begin') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+        serverId = data.serverId
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+        serverPublicKey = data.publicKey
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+        serverVerifyToken = data.verifyToken
+      }
+    })
+  })
+}


### PR DESCRIPTION
"Overcomplicated" access token login.
- Full Authentication flow with MS refresh token input (+ caching)
- Added example in config_example.yaml

Fixed up some other things
- Linter and TSC are happy now