### PR TITLE
Enhance: Client status now is full words

### DIFF
--- a/src/common/ClientInstance.ts
+++ b/src/common/ClientInstance.ts
@@ -34,19 +34,19 @@ export enum Status {
   /**
    * Freshly created instance
    */
-  FRESH,
+  FRESH = 'FRESH',
   /**
    * Instance is connecting for first time
    */
-  CONNECTING,
+  CONNECTING = 'CONNECTING',
   /**
    * Instance is trying to connect with its own private client
    */
-  CONNECTED,
+  CONNECTED = 'CONNECTED',
   /**
    * Instance has decided to shut down for a critical reason
    */
-  FAILED
+  FAILED = 'FAILED'
 }
 
 export enum LOCATION {


### PR DESCRIPTION
 instead of numbers when displayed.

Example of old display message 
![image](https://github.com/aidn3/hypixel-guild-discord-bridge/assets/24919899/b3205d64-5e30-48d0-9702-873c88de7781)
