### PR TITLE
chore(metrics): Replace a deprecated node method

### DIFF
--- a/src/instance/metrics/metrics-instance.ts
+++ b/src/instance/metrics/metrics-instance.ts
@@ -1,5 +1,4 @@
 import http from 'node:http'
-import url from 'node:url'
 
 import { HttpStatusCode } from 'axios'
 import * as Client from 'prom-client'
@@ -50,7 +49,7 @@ export default class MetricsInstance extends ClientInstance<MetricsConfig> {
         return
       }
 
-      const route = url.parse(request.url).pathname
+      const route = request.url.split('?')[0]
       if (route === '/metrics') {
         this.logger.debug('Metrics scrap is called on /metrics')
         response.setHeader('Content-Type', this.register.contentType)


### PR DESCRIPTION
url.parse() was deprecated. It was replaced with a simple string split. 
request.url returned the entire path after the hostname like "/path?query=value".