### PR TITLE
fix(discord): /invite doesn't detect full guild

### DIFF
--- a/src/instance/discord/common/chat-triggers.ts
+++ b/src/instance/discord/common/chat-triggers.ts
@@ -96,7 +96,8 @@ export const INVITE_ACCEPT_CHAT: RegexChat = {
     /^You cannot invite this player to your guild!/,
     /^(?:\[[+A-Z]{1,10}] )*(\w{3,32}) is already in another guild!/,
     /^(?:\[[+A-Z]{1,10}] )*(\w{3,32}) is already in your guild!/,
-    /^Already in a guild!/
+    /^Already in a guild!/,
+    /^Your guild is full!/
   ]
 }
 


### PR DESCRIPTION
Discovered by `nicedoggo` on Discord.