### PR TITLE
fix(commands): switch !rtca args

### DIFF
--- a/src/instance/commands/triggers/runs-to-class-average.ts
+++ b/src/instance/commands/triggers/runs-to-class-average.ts
@@ -29,8 +29,8 @@ export default class RunsToClassAverage extends ChatCommandHandler {
   }
 
   async handler(context: ChatCommandContext): Promise<string> {
-    const targetAverage = context.args[0] ? Number.parseInt(context.args[0], 10) : 50
-    const givenUsername = context.args[1] ?? context.username
+    const givenUsername = context.args[0] ?? context.username
+    const targetAverage = context.args[1] ? Number.parseInt(context.args[1], 10) : 50
 
     const uuid = await getUuidIfExists(context.app.mojangApi, givenUsername)
     if (uuid == undefined) {


### PR DESCRIPTION
People are used to always have the first argument be the username. They are getting confused. Will close #193