### PR TITLE
chores(lint): enforce import/no-restricted-paths

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,112 @@
         "checkArguments": false,
         "checkArrowFunctionBody": false
       }
+    ],
+    "import/no-restricted-paths": [
+      "error",
+      {
+        "zones": [
+          {
+            "target": "src/common",
+            "from": ["src/instance", "src/plugins", "src/types", "src/util"],
+            "message": "Common files are used as public api and must not reference internal files"
+          },
+          {
+            "target": "src/plugins",
+            "from": ["src/plugins", "src/types"],
+            "message": "Plugin files must not reference other plugins or outside files"
+          },
+          {
+            "target": "src/types",
+            "from": ["src"],
+            "message": "Type files must only reference published libraries"
+          },
+          {
+            "target": "src/util",
+            "from": ["src/instance", "src/plugins", "src/types"],
+            "message": "Util must only reference other common files. Specific util can be put in their respective instance common dir."
+          },
+
+          {
+            "target": "src/instance/commands",
+            "from": [
+              "src/plugins",
+              "src/types",
+              "src/instance/discord",
+              "src/instance/logger",
+              "src/instance/metrics",
+              "src/instance/minecraft",
+              "src/instance/socket"
+            ],
+            "message": "Instance must only access itself and common files"
+          },
+          {
+            "target": "src/instance/discord",
+            "from": [
+              "src/plugins",
+              "src/types",
+              "src/instance/commands",
+              "src/instance/logger",
+              "src/instance/metrics",
+              "src/instance/minecraft",
+              "src/instance/socket"
+            ],
+            "message": "Instance must only access itself and common files"
+          },
+          {
+            "target": "src/instance/logger",
+            "from": [
+              "src/plugins",
+              "src/types",
+              "src/instance/commands",
+              "src/instance/discord",
+              "src/instance/metrics",
+              "src/instance/minecraft",
+              "src/instance/socket"
+            ],
+            "message": "Instance must only access itself and common files"
+          },
+          {
+            "target": "src/instance/metrics",
+            "from": [
+              "src/plugins",
+              "src/types",
+              "src/instance/commands",
+              "src/instance/discord",
+              "src/instance/logger",
+              "src/instance/minecraft",
+              "src/instance/socket"
+            ],
+            "message": "Instance must only access itself and common files"
+          },
+          {
+            "target": "src/instance/minecraft",
+            "from": [
+              "src/plugins",
+              "src/types",
+              "src/instance/commands",
+              "src/instance/discord",
+              "src/instance/logger",
+              "src/instance/metrics",
+              "src/instance/socket"
+            ],
+            "message": "Instance must only access itself and common files"
+          },
+          {
+            "target": "src/instance/socket",
+            "from": [
+              "src/plugins",
+              "src/types",
+              "src/instance/commands",
+              "src/instance/discord",
+              "src/instance/logger",
+              "src/instance/metrics",
+              "src/instance/minecraft"
+            ],
+            "message": "Instance must only access itself and common files"
+          }
+        ]
+      }
     ]
   },
   "settings": {

--- a/src/common/plugins.ts
+++ b/src/common/plugins.ts
@@ -1,7 +1,10 @@
 import type { Logger } from 'log4js'
 
 import type Application from '../application.js'
+// TODO: fix by either creating special rule in linting or by removing this functionality to meet the standard
+// eslint-disable-next-line import/no-restricted-paths
 import type { ChatCommandHandler } from '../instance/commands/common/command-interface.js'
+// eslint-disable-next-line import/no-restricted-paths
 import type { CommandInterface } from '../instance/discord/common/command-interface.js'
 
 import type { ClientInstance } from './client-instance.js'


### PR DESCRIPTION
This is useful for future contributors to know what not to import. This will ensure the code base stays clean and not become a spaghetti mess.