### PR TITLE
feat(discord): forward more events to discord officer chat

### DIFF
--- a/src/instance/discord/discord-instance.ts
+++ b/src/instance/discord/discord-instance.ts
@@ -134,14 +134,51 @@ export default class DiscordInstance extends ClientInstance<DiscordConfig> {
       }
     }
 
-    let channels: string[]
-    if (event.channelType === ChannelType.PUBLIC) {
-      channels = this.config.publicChannelIds
-    } else if (event.channelType === ChannelType.OFFICER) {
-      channels = this.config.officerChannelIds
-    } else {
-      return
+    const channels: string[] = []
+
+    switch (event.eventType) {
+      case EventType.AUTOMATED: {
+        if (event.channelType === ChannelType.PUBLIC) {
+          channels.push(...this.config.publicChannelIds)
+        } else if (event.channelType === ChannelType.OFFICER) {
+          channels.push(...this.config.officerChannelIds)
+        } else {
+          return
+        }
+        break
+      }
+
+      case EventType.REQUEST:
+      case EventType.JOIN:
+      case EventType.LEAVE:
+      case EventType.KICK:
+      case EventType.PROMOTE:
+      case EventType.DEMOTE: {
+        channels.push(...this.config.publicChannelIds, ...this.config.officerChannelIds)
+        break
+      }
+
+      case EventType.MUTE:
+      case EventType.UNMUTE: {
+        channels.push(...this.config.officerChannelIds)
+        break
+      }
+
+      case EventType.BLOCK:
+      case EventType.MUTED:
+      case EventType.OFFLINE:
+      case EventType.ONLINE:
+      case EventType.QUEST:
+      case EventType.REPEAT: {
+        channels.push(...this.config.publicChannelIds)
+        break
+      }
+
+      default: {
+        return
+      }
     }
+
     const embed = {
       description: escapeDiscord(event.message),
 


### PR DESCRIPTION
Discord officer chat used to be mostly empty and out of touch unlike public chat. This update forwards a copy of events from public to officer making the officer chat a moderator log.

Public only: block due to wording in sent message, bot muted, offline/online player, quest completion, cannot repeat
Officer only: mute/unmute player
both: request to join, join/leave, kick, promote/demote
automated scripting from plugins is left to each script own discretion.

This close #189 