### PR TITLE
fix(deps): revert and ensure bad-words doesn't update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hkh12/node-calc": "^4.2.1",
         "axios": "^1.7.2",
-        "bad-words": "^4.0.0",
+        "bad-words": "^3.0.4",
         "discord.js": "^14.15.3",
         "emoji-name-map": "^1.2.9",
         "hypixel-api-reborn": "^11.2.1",
@@ -1166,21 +1166,21 @@
       }
     },
     "node_modules/bad-words": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-4.0.0.tgz",
-      "integrity": "sha512-fLjG/I0N3I7xhurqGnGitSRD10UeEE63a7hyXtutQDpxo4+Eal+i7veWeZxZJPNtsl6X1mUIoWPwt8gQ7NMQUw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
+      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
       "license": "MIT",
       "dependencies": {
-        "badwords-list": "^2.0.1-4"
+        "badwords-list": "^1.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/badwords-list": {
-      "version": "2.0.1-4",
-      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-2.0.1-4.tgz",
-      "integrity": "sha512-FxfZUp7B9yCnesNtFQS9v6PvZdxTYa14Q60JR6vhjdQdWI4naTjJIyx22JzoER8ooeT8SAAKoHLjKfCV7XgYUQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
+      "integrity": "sha512-oWhaSG67e+HQj3OGHQt2ucP+vAPm1wTbdp2aDHeuh4xlGXBdWwzZ//pfu6swf5gZ8iX0b7JgmSo8BhgybbqszA==",
       "license": "MIT"
     },
     "node_modules/balanced-match": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hkh12/node-calc": "^4.2.1",
         "axios": "^1.7.2",
-        "bad-words": "^3.0.4",
+        "bad-words": "3.0.4",
         "discord.js": "^14.15.3",
         "emoji-name-map": "^1.2.9",
         "hypixel-api-reborn": "^11.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@hkh12/node-calc": "^4.2.1",
     "axios": "^1.7.2",
-    "bad-words": "^4.0.0",
+    "bad-words": "^3.0.4",
     "discord.js": "^14.15.3",
     "emoji-name-map": "^1.2.9",
     "hypixel-api-reborn": "^11.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@hkh12/node-calc": "^4.2.1",
     "axios": "^1.7.2",
-    "bad-words": "^3.0.4",
+    "bad-words": "3.0.4",
     "discord.js": "^14.15.3",
     "emoji-name-map": "^1.2.9",
     "hypixel-api-reborn": "^11.2.1",

--- a/src/application.ts
+++ b/src/application.ts
@@ -2,7 +2,7 @@ import type Events from 'node:events'
 import path from 'node:path'
 import * as process from 'node:process'
 
-import { Filter } from 'bad-words'
+import BadWords from 'bad-words'
 import { Client as HypixelClient } from 'hypixel-api-reborn'
 import type { Logger } from 'log4js'
 import log4js from 'log4js'
@@ -41,7 +41,7 @@ export default class Application extends TypedEmitter<ApplicationEvents> {
 
   readonly clusterHelper: ClusterHelper
   readonly punishedUsers: PunishedUsers
-  readonly profanityFilter: Filter
+  readonly profanityFilter: BadWords.BadWords
 
   readonly hypixelApi: HypixelClient
   readonly mojangApi: MojangApi
@@ -64,7 +64,7 @@ export default class Application extends TypedEmitter<ApplicationEvents> {
     this.punishedUsers = new PunishedUsers(this)
     this.clusterHelper = new ClusterHelper(this)
 
-    this.profanityFilter = new Filter({
+    this.profanityFilter = new BadWords({
       emptyList: !this.config.profanity.enabled
     })
     this.profanityFilter.removeWords(...this.config.profanity.whitelisted)

--- a/src/types/bad-words.d.ts
+++ b/src/types/bad-words.d.ts
@@ -1,0 +1,24 @@
+declare module 'bad-words' {
+  interface BadWordsConstructor {
+    new (options?: BadWordsOptions): BadWords
+
+    (options?: BadWordsOptions): BadWords
+  }
+
+  declare const constructor: BadWordsConstructor
+  export = constructor
+
+  export class BadWords {
+    addWords: (...words: string) => void
+    clean: (text: string) => string
+    removeWords: (...arguments_: string[]) => void
+  }
+
+  export interface BadWordsOptions {
+    emptyList?: boolean
+    list?: string[]
+    placeHolder?: string
+    regex?: string
+    replaceRegex?: string
+  }
+}


### PR DESCRIPTION
the new major version of bad-words is too buggy to be even released.

Some of the bugs found:
- removes any underscore if it comes directly after \w
- new line character will result in all words seperated by a space to start and end with an underscore like _\w+_
- isProfane() function isn't accurate at all and has different results from the rest of the functions including clean()