### PR TITLE
refactor(app): enable @typescript-eslint/naming-convention

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,42 @@
     "import/newline-after-import": 2,
     "import/no-extraneous-dependencies": 2,
     "@typescript-eslint/consistent-type-imports": 2,
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "default",
+        "leadingUnderscore": "forbid",
+        "trailingUnderscore": "forbid",
+        "format": ["camelCase"]
+      },
+      {
+        "selector": ["class", "interface", "enum", "enumMember", "typeAlias", "typeParameter"],
+        "format": ["PascalCase"]
+      },
+      {
+        "selector": ["import"],
+        "filter": {
+          "match": false,
+          "regex": "(fs|http|console|process|path|assert)"
+        },
+        "format": ["PascalCase"]
+      },
+      {
+        "selector": ["classProperty"],
+        "format": ["PascalCase"],
+        "modifiers": ["static"]
+      },
+      {
+        "selector": ["variable"],
+        "format": ["PascalCase", "camelCase"],
+        "modifiers": ["const"]
+      },
+      {
+        "selector": ["variable"],
+        "format": ["PascalCase"],
+        "modifiers": ["const", "global"]
+      }
+    ],
     "@typescript-eslint/restrict-template-expressions": [
       "error",
       {

--- a/index.ts
+++ b/index.ts
@@ -1,47 +1,55 @@
+import * as console from 'node:console'
+import fs from 'node:fs'
 import path from 'node:path'
 
-import log4js from 'log4js'
+import Logger4js from 'log4js'
 
-import logConfig from './config/log4js-config.json' with { type: 'json' }
-import packageJson from './package.json' with { type: 'json' }
+import LoggerConfig from './config/log4js-config.json' with { type: 'json' }
+import PackageJson from './package.json' with { type: 'json' }
 import Application from './src/application.js'
 import { loadApplicationConfig } from './src/configuration-parser.js'
 import { shutdownApplication } from './src/util/shared-util.js'
 
 console.log('Loading Logger...')
 // eslint-disable-next-line import/no-named-as-default-member
-const logger = log4js.configure(logConfig).getLogger('Main')
+const Logger = Logger4js.configure(LoggerConfig).getLogger('Main')
 
-logger.debug('Setting up process...')
+Logger.debug('Setting up process...')
 process.on('uncaughtException', function (error) {
-  logger.fatal(error)
+  Logger.fatal(error)
   process.exitCode = 1
 })
 
-process.title = packageJson.name
+process.title = PackageJson.name
 
 if (process.argv.includes('test-run')) {
-  logger.warn('Argument passed to run in testing mode')
-  logger.warn('Test Loading finished.')
-  logger.warn('Returning from program with exit code 0')
-  shutdownApplication(0)
+  Logger.warn('Argument passed to run in testing mode')
+  Logger.warn('Test Loading finished.')
+  Logger.warn('Returning from program with exit code 0')
+  await shutdownApplication(0)
 }
 
-const file = process.argv[2] ?? './config.yaml'
+const File = process.argv[2] ?? './config.yaml'
+if (!fs.existsSync(File)) {
+  Logger.fatal(`File ${File} does not exist.`)
+  Logger.fatal(`You can rename config_example.yaml to config.yaml and use it as the configuration file.`)
+  Logger.fatal(`If this is the first time running the application, please read README.md before proceeding.`)
+  await shutdownApplication(1)
+}
 
-const rootDirectory = import.meta.dirname
-const configsDirectory = path.resolve(rootDirectory, 'config')
-const app = new Application(loadApplicationConfig(file), rootDirectory, configsDirectory)
+const RootDirectory = import.meta.dirname
+const ConfigsDirectory = path.resolve(RootDirectory, 'config')
+const App = new Application(loadApplicationConfig(File), RootDirectory, ConfigsDirectory)
 
-app.on('*', (name, event) => {
-  logger.log(`[${name}] ${JSON.stringify(event)}`)
+App.on('*', (name, event) => {
+  Logger.log(`[${name}] ${JSON.stringify(event)}`)
 })
 
 try {
-  await app.sendConnectSignal()
-  logger.info('App is connected')
+  await App.sendConnectSignal()
+  Logger.info('App is connected')
 } catch (error: unknown) {
-  logger.fatal(error)
-  logger.fatal('stopping the process for the controller to restart this node...')
+  Logger.fatal(error)
+  Logger.fatal('stopping the process for the controller to restart this node...')
   process.exit(1)
 }

--- a/src/application.ts
+++ b/src/application.ts
@@ -5,7 +5,7 @@ import * as process from 'node:process'
 import BadWords from 'bad-words'
 import { Client as HypixelClient } from 'hypixel-api-reborn'
 import type { Logger } from 'log4js'
-import log4js from 'log4js'
+import Logger4js from 'log4js'
 import { TypedEmitter } from 'tiny-typed-emitter'
 
 import type { ApplicationConfig } from './application-config.js'
@@ -49,7 +49,7 @@ export default class Application extends TypedEmitter<ApplicationEvents> {
   constructor(config: ApplicationConfig, rootDirectory: string, configsDirectory: string) {
     super()
     // eslint-disable-next-line import/no-named-as-default-member
-    this.logger = log4js.getLogger('Application')
+    this.logger = Logger4js.getLogger('Application')
     this.logger.trace('Application initiating')
     emitAll(this) // first thing to redirect all events
     this.config = config
@@ -167,7 +167,7 @@ export default class Application extends TypedEmitter<ApplicationEvents> {
       const loadedPlugin = await p.promise
       loadedPlugin.onRun({
         // eslint-disable-next-line import/no-named-as-default-member
-        logger: log4js.getLogger(`plugin-${p.name}`),
+        logger: Logger4js.getLogger(`plugin-${p.name}`),
         pluginName: p.name,
         application: this,
         // only shared with plugins to directly modify instances
@@ -226,13 +226,12 @@ export default class Application extends TypedEmitter<ApplicationEvents> {
   }
 }
 
+/* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-argument */
 function emitAll(emitter: Events): void {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
   const old = emitter.emit
   emitter.emit = (event: string, ...arguments_): boolean => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     if (event !== '*') emitter.emit('*', event, ...arguments_)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return old.call(emitter, event, ...arguments_)
   }
 }
+/* eslint-enable @typescript-eslint/naming-convention, @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-argument */

--- a/src/common/application-event.ts
+++ b/src/common/application-event.ts
@@ -7,6 +7,7 @@ export interface ApplicationEvents {
    * @param name event name
    * @param event event object
    */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   '*': (name: string, event: BaseEvent) => void
 
   /**
@@ -354,7 +355,8 @@ export interface CommandEvent extends InformEvent {
    */
   readonly commandResponse: string
 }
-
+// TODO: remove on major update
+/* eslint-disable @typescript-eslint/naming-convention */
 /**
  * Enum containing all available instance statuses
  */
@@ -389,6 +391,7 @@ export enum InstanceEventType {
    */
   kick
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
 /**
  * Events used when an instance changes its status

--- a/src/common/client-instance.ts
+++ b/src/common/client-instance.ts
@@ -1,5 +1,5 @@
 import type { Logger } from 'log4js'
-import log4js from 'log4js'
+import Logger4js from 'log4js'
 
 import type Application from '../application.js'
 
@@ -19,7 +19,7 @@ export abstract class ClientInstance<K> {
     this.instanceName = instanceName
     this.instanceType = instanceType
     // eslint-disable-next-line import/no-named-as-default-member
-    this.logger = log4js.getLogger(instanceName)
+    this.logger = Logger4js.getLogger(instanceName)
     this.config = config
     this.status = Status.FRESH
   }
@@ -54,4 +54,5 @@ export enum Status {
   FAILED = 'FAILED'
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const INTERNAL_INSTANCE_PREFIX = 'internal/'

--- a/src/configuration-parser.ts
+++ b/src/configuration-parser.ts
@@ -6,11 +6,11 @@ import YAML from 'yaml'
 import ApplicationConfigTi from './application-config-ti.js'
 import type { ApplicationConfig } from './application-config.js'
 
-const applicationConfigChecker = createCheckers(ApplicationConfigTi)
+const ApplicationConfigChecker = createCheckers(ApplicationConfigTi)
 
 export function loadApplicationConfig(filepath: fs.PathOrFileDescriptor): ApplicationConfig {
   const fileString = fs.readFileSync(filepath, 'utf8')
   const config = YAML.parse(fileString) as unknown
-  applicationConfigChecker.ApplicationConfig.check(config)
+  ApplicationConfigChecker.ApplicationConfig.check(config)
   return config as ApplicationConfig
 }

--- a/src/instance/commands/common/command-interface.ts
+++ b/src/instance/commands/common/command-interface.ts
@@ -1,4 +1,4 @@
-import type * as log4js from 'log4js'
+import type * as Logger4js from 'log4js'
 
 import type Application from '../../../application.js'
 import type { ChannelType, InstanceType } from '../../../common/application-event.js'
@@ -27,7 +27,7 @@ export abstract class ChatCommandHandler {
 export interface ChatCommandContext {
   app: Application
 
-  logger: log4js.Logger
+  logger: Logger4js.Logger
   allCommands: ChatCommandHandler[]
   commandPrefix: string
   adminUsername: string

--- a/src/instance/commands/common/util.ts
+++ b/src/instance/commands/common/util.ts
@@ -35,20 +35,20 @@ export async function getSelectedSkyblockProfile(hypixelApi: Client, uuid: strin
 }
 
 export function getDungeonLevelWithOverflow(experience: number): number {
-  const DUNGEON_XP = [
+  const DungeonXp = [
     50, 75, 110, 160, 230, 330, 470, 670, 950, 1340, 1890, 2665, 3760, 5260, 7380, 10_300, 14_400, 20_000, 27_600,
     38_000, 52_500, 71_500, 97_000, 132_000, 180_000, 243_000, 328_000, 445_000, 600_000, 800_000, 1_065_000, 1_410_000,
     1_900_000, 2_500_000, 3_300_000, 4_300_000, 5_600_000, 7_200_000, 9_200_000, 1.2e7, 1.5e7, 1.9e7, 2.4e7, 3e7, 3.8e7,
     4.8e7, 6e7, 7.5e7, 9.3e7, 1.1625e8
   ]
-  const PER_LEVEL = 200_000_000
-  const MAX_50_XP = 569_809_640
+  const PerLevel = 200_000_000
+  const Max50Xp = 569_809_640
 
-  if (experience > MAX_50_XP) {
+  if (experience > Max50Xp) {
     // account for overflow
-    const remainingExperience = experience - MAX_50_XP
-    const extraLevels = Math.floor(remainingExperience / PER_LEVEL)
-    const fractionLevel = (remainingExperience % PER_LEVEL) / PER_LEVEL
+    const remainingExperience = experience - Max50Xp
+    const extraLevels = Math.floor(remainingExperience / PerLevel)
+    const fractionLevel = (remainingExperience % PerLevel) / PerLevel
 
     return 50 + extraLevels + fractionLevel
   }
@@ -56,7 +56,7 @@ export function getDungeonLevelWithOverflow(experience: number): number {
   let totalLevel = 0
   let remainingXP = experience
 
-  for (const [index, levelXp] of DUNGEON_XP.entries()) {
+  for (const [index, levelXp] of DungeonXp.entries()) {
     if (remainingXP > levelXp) {
       totalLevel = index + 1
       remainingXP -= levelXp
@@ -65,6 +65,6 @@ export function getDungeonLevelWithOverflow(experience: number): number {
     }
   }
 
-  const fractionLevel = remainingXP / DUNGEON_XP[totalLevel]
+  const fractionLevel = remainingXP / DungeonXp[totalLevel]
   return totalLevel + fractionLevel
 }

--- a/src/instance/commands/triggers/bits.ts
+++ b/src/instance/commands/triggers/bits.ts
@@ -4,11 +4,12 @@
  Minecraft username: Callanplays
 */
 import type { AxiosResponse } from 'axios'
-import axios from 'axios'
+import Axios from 'axios'
 
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
 
+/* eslint-disable @typescript-eslint/naming-convention */
 const BitItem: Record<string, { bitValue: number; prettyName: string }> = {
   GOD_POTION_2: { bitValue: 1500, prettyName: 'Godpot' },
   KISMET_FEATHER: { bitValue: 1350, prettyName: 'Kismet' },
@@ -58,9 +59,10 @@ const BitItem: Record<string, { bitValue: number; prettyName: string }> = {
   TALISMAN_ENRICHMENT_ATTACK_SPEED: { bitValue: 5000, prettyName: 'Atk Spd Enrich' },
   TALISMAN_ENRICHMENT_SWAPPER: { bitValue: 200, prettyName: 'Acc Enrich Swapper' }
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export default class Bits extends ChatCommandHandler {
-  private static readonly UPDATE_PRICES_EVERY = 5 * 60 * 1000 // 5 minute
+  private static readonly UpdatePriceEvery = 5 * 60 * 1000 // 5 minute
   private lastPricesUpdateAt = 0
   private prices: { itemId: string; sellPrice: number }[] = []
 
@@ -75,7 +77,7 @@ export default class Bits extends ChatCommandHandler {
 
   async handler(context: ChatCommandContext): Promise<string> {
     const currentTime = Date.now()
-    if (this.lastPricesUpdateAt + Bits.UPDATE_PRICES_EVERY < currentTime) {
+    if (this.lastPricesUpdateAt + Bits.UpdatePriceEvery < currentTime) {
       await this.updatePrices()
       this.lastPricesUpdateAt = currentTime
     }
@@ -90,9 +92,9 @@ export default class Bits extends ChatCommandHandler {
   }
 
   private async updatePrices(): Promise<void> {
-    const response = await axios
-      .get(`https://moulberry.codes/lowestbin.json`)
-      .then((response: AxiosResponse<Record<string, number>, unknown>) => response.data)
+    const response = await Axios.get(`https://moulberry.codes/lowestbin.json`).then(
+      (response: AxiosResponse<Record<string, number>, unknown>) => response.data
+    )
 
     this.prices = Object.entries(response)
       .filter(([itemId]) => Object.hasOwn(BitItem, itemId))

--- a/src/instance/commands/triggers/networth.ts
+++ b/src/instance/commands/triggers/networth.ts
@@ -5,7 +5,7 @@
 */
 import assert from 'node:assert'
 
-import axios, { type AxiosResponse } from 'axios'
+import Axios, { type AxiosResponse } from 'axios'
 import { getNetworth, getPrices } from 'skyhelper-networth'
 
 import type { ChatCommandContext } from '../common/command-interface.js'
@@ -44,10 +44,9 @@ export default class Networth extends ChatCommandHandler {
       .then((response) => response.profiles.find((p) => p.selected))
     assert(selectedProfile)
 
-    const museumData = await axios
-      .get(
-        `https://api.hypixel.net/skyblock/museum?key=${context.app.hypixelApi.key}&profile=${selectedProfile.profile_id}`
-      )
+    const museumData = await Axios.get(
+      `https://api.hypixel.net/skyblock/museum?key=${context.app.hypixelApi.key}&profile=${selectedProfile.profile_id}`
+    )
       .then((response: AxiosResponse<HypixelSkyblockMuseumRaw, unknown>) => response.data)
       .then((museum) => museum.members[uuid] as object)
 

--- a/src/instance/commands/triggers/slayer.ts
+++ b/src/instance/commands/triggers/slayer.ts
@@ -13,7 +13,8 @@ const Slayers: Record<string, string[]> = {
   vampire: ['riftstalker', 'bloodfiend', 'vamp', 'vampire'],
   overview: ['all', 'summary']
 }
-const slayerExpTable = {
+const SlayerExpTable = {
+  /* eslint-disable @typescript-eslint/naming-convention */
   1: 5,
   2: 15,
   3: 200,
@@ -23,16 +24,19 @@ const slayerExpTable = {
   7: 100_000,
   8: 400_000,
   9: 1_000_000
+  /* eslint-enable @typescript-eslint/naming-convention */
 }
-const vampExpTable = {
+const VampExpTable = {
+  /* eslint-disable @typescript-eslint/naming-convention */
   1: 20,
   2: 75,
   3: 240,
   4: 840,
   5: 2400
+  /* eslint-enable @typescript-eslint/naming-convention */
 }
 
-const highestTierTable = {
+const HighestTierTable = {
   // 1 less due to index starting at 0
   zombie: 4,
   spider: 3,
@@ -94,10 +98,10 @@ export default class Slayer extends ChatCommandHandler {
 
     if (slayer === 'vampire') {
       maxLevel = 5 // vampire slayer only goes to level 5
-      expTable = vampExpTable
+      expTable = VampExpTable
     } else {
       maxLevel = 9
-      expTable = slayerExpTable
+      expTable = SlayerExpTable
     }
 
     let level = 0
@@ -108,7 +112,7 @@ export default class Slayer extends ChatCommandHandler {
   }
 
   private getHighestTierKills(slayerData: SlayerType, slayerName: string): number {
-    const highestTier = highestTierTable[slayerName as keyof typeof highestTierTable]
+    const highestTier = HighestTierTable[slayerName as keyof typeof HighestTierTable]
     const index = `boss_kills_tier_${highestTier}`
     return slayerData[index as keyof SlayerType] ?? 0
   }

--- a/src/instance/commands/triggers/soopy.ts
+++ b/src/instance/commands/triggers/soopy.ts
@@ -1,13 +1,13 @@
 import type { AxiosResponse } from 'axios'
-import axios from 'axios'
+import Axios from 'axios'
 import NodeCache from 'node-cache'
 
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
 
 export default class Soopy extends ChatCommandHandler {
-  private readonly SOOPY_API_URL = 'https://soopy.dev/api/soopyv2/botcommand'
-  private readonly ALLOWED_COMMANDS = [
+  private static readonly SoopyApiUrl = 'https://soopy.dev/api/soopyv2/botcommand'
+  private static readonly AllowedCommands = [
     'kuudra',
     'bazzar',
     'bz',
@@ -101,7 +101,7 @@ export default class Soopy extends ChatCommandHandler {
 
     const fullCommand = `${commandName} ${commandArguments.join(' ')}`
 
-    if (!this.ALLOWED_COMMANDS.includes(commandName.toLowerCase())) {
+    if (!Soopy.AllowedCommands.includes(commandName.toLowerCase())) {
       return `${context.username}, command not defined or allowed to use with Soopy!`
     }
 
@@ -111,9 +111,10 @@ export default class Soopy extends ChatCommandHandler {
     }
 
     try {
-      const result = await axios
-        .get(this.SOOPY_API_URL, { timeout: 2 * 60 * 1000, data: { m: fullCommand, u: context.username } })
-        .then((response: AxiosResponse<string, unknown>) => response.data)
+      const result = await Axios.get(Soopy.SoopyApiUrl, {
+        timeout: 2 * 60 * 1000,
+        data: { m: fullCommand, u: context.username }
+      }).then((response: AxiosResponse<string, unknown>) => response.data)
 
       this.cache.set(Soopy.createCacheKey(context.username, fullCommand), result)
       return Soopy.formatResponse(context.username, result)

--- a/src/instance/commands/triggers/weight.ts
+++ b/src/instance/commands/triggers/weight.ts
@@ -5,7 +5,7 @@
 */
 import assert from 'node:assert'
 
-import axios, { type AxiosResponse } from 'axios'
+import Axios, { type AxiosResponse } from 'axios'
 
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
@@ -26,7 +26,7 @@ export default class Weight extends ChatCommandHandler {
   }
 
   private async getSenitherData(username: string): Promise<number> {
-    const skyShiiyuResponse = await axios(`https://sky.shiiyu.moe/api/v2/profile/${username}`).then(
+    const skyShiiyuResponse = await Axios(`https://sky.shiiyu.moe/api/v2/profile/${username}`).then(
       (response: AxiosResponse<SkyShiiyuResponse, unknown>) => response.data
     )
 

--- a/src/instance/discord/chat-manager.ts
+++ b/src/instance/discord/chat-manager.ts
@@ -1,6 +1,6 @@
-import axios, { type AxiosResponse } from 'axios'
+import Axios, { type AxiosResponse } from 'axios'
 import type { Message, TextChannel } from 'discord.js'
-import emojisMap from 'emoji-name-map'
+import EmojisMap from 'emoji-name-map'
 
 import { ChannelType, InstanceType, PunishmentType } from '../../common/application-event.js'
 import EventHandler from '../../common/event-handler.js'
@@ -149,7 +149,7 @@ export default class ChatManager extends EventHandler<DiscordInstance> {
   }
 
   private cleanStandardEmoji(message: string): string {
-    for (const [emojiReadable, emojiUnicode] of Object.entries(emojisMap.emoji)) {
+    for (const [emojiReadable, emojiUnicode] of Object.entries(EmojisMap.emoji)) {
       message = message.replaceAll(emojiUnicode, `:${emojiReadable}:`)
     }
 
@@ -183,15 +183,15 @@ export default class ChatManager extends EventHandler<DiscordInstance> {
     const encoded = 'Q-2-x-p-Z-W-5-0-L-U-l-E-I-D-Y-0-O-W-Y-y-Z-m-I-0-O-G-U-1-O-T-c-2-N-w-=-='
     const decoded = Buffer.from(encoded.replaceAll('-', ''), 'base64').toString('utf8')
 
-    const result = await axios
-      .post(
-        'https://api.imgur.com/3/image',
-        {
-          image: link,
-          type: 'url'
-        },
-        { headers: { Authorization: decoded } }
-      )
+    const result = await Axios.post(
+      'https://api.imgur.com/3/image',
+      {
+        image: link,
+        type: 'url'
+      },
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      { headers: { Authorization: decoded } }
+    )
       .then((response: AxiosResponse<ImgurResponse, unknown>) => {
         return response.data.data.link
       })

--- a/src/instance/discord/commands/accept.ts
+++ b/src/instance/discord/commands/accept.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from 'discord.js'
 
 import { escapeDiscord } from '../../../util/shared-util.js'
-import { checkChatTriggers, formatChatTriggerResponse, INVITE_ACCEPT_CHAT } from '../common/chat-triggers.js'
+import { checkChatTriggers, formatChatTriggerResponse, InviteAcceptChat } from '../common/chat-triggers.js'
 import type { CommandInterface } from '../common/command-interface.js'
 import { Permission } from '../common/command-interface.js'
 
@@ -25,7 +25,7 @@ export default {
     const instance: string | null = context.interaction.options.getString('instance')
     const result = await checkChatTriggers(
       context.application,
-      INVITE_ACCEPT_CHAT,
+      InviteAcceptChat,
       instance ?? undefined,
       command,
       username

--- a/src/instance/discord/commands/connectivity.ts
+++ b/src/instance/discord/commands/connectivity.ts
@@ -64,7 +64,7 @@ export default {
   }
 } satisfies CommandInterface
 
-const checkConnectivity = async function (app: Application): Promise<Map<string, string[]>> {
+async function checkConnectivity(app: Application): Promise<Map<string, string[]>> {
   const receivedResponses = new Map<string, string[]>()
   const queryWords = [
     `Testing Connectivity 1 - @${antiSpamString()}`,

--- a/src/instance/discord/commands/demote.ts
+++ b/src/instance/discord/commands/demote.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from 'discord.js'
 
 import { escapeDiscord } from '../../../util/shared-util.js'
-import { checkChatTriggers, formatChatTriggerResponse, RANK_CHAT } from '../common/chat-triggers.js'
+import { checkChatTriggers, formatChatTriggerResponse, RankChat } from '../common/chat-triggers.js'
 import type { CommandInterface } from '../common/command-interface.js'
 import { Permission } from '../common/command-interface.js'
 
@@ -22,7 +22,7 @@ export default {
     const username: string = context.interaction.options.getString('username', true)
     const command = `/g demote ${username}`
 
-    const result = await checkChatTriggers(context.application, RANK_CHAT, undefined, command, username)
+    const result = await checkChatTriggers(context.application, RankChat, undefined, command, username)
     const formatted = formatChatTriggerResponse(result, `Demote ${escapeDiscord(username)}`)
 
     await context.interaction.editReply({ embeds: [formatted] })

--- a/src/instance/discord/commands/invite.ts
+++ b/src/instance/discord/commands/invite.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from 'discord.js'
 
 import { escapeDiscord } from '../../../util/shared-util.js'
-import { checkChatTriggers, formatChatTriggerResponse, INVITE_ACCEPT_CHAT } from '../common/chat-triggers.js'
+import { checkChatTriggers, formatChatTriggerResponse, InviteAcceptChat } from '../common/chat-triggers.js'
 import type { CommandInterface } from '../common/command-interface.js'
 import { Permission } from '../common/command-interface.js'
 
@@ -25,7 +25,7 @@ export default {
     const instance: string | null = context.interaction.options.getString('instance')
     const result = await checkChatTriggers(
       context.application,
-      INVITE_ACCEPT_CHAT,
+      InviteAcceptChat,
       instance ?? undefined,
       command,
       username

--- a/src/instance/discord/commands/list.ts
+++ b/src/instance/discord/commands/list.ts
@@ -36,10 +36,10 @@ function createEmbed(instances: Map<string, string[]>): APIEmbed[] {
 
   const pages = []
 
-  const MAX_LENGTH = 3900
+  const MaxLength = 3900
   let currentLength = 0
   for (const entry of entries) {
-    if (pages.length === 0 || currentLength + entry.length > MAX_LENGTH) {
+    if (pages.length === 0 || currentLength + entry.length > MaxLength) {
       currentLength = 0
 
       pages.push({
@@ -84,11 +84,7 @@ export default {
   }
 } satisfies CommandInterface
 
-const listMembers = async function (
-  app: Application,
-  mojangApi: MojangApi,
-  hypixelApi: Client
-): Promise<Map<string, string[]>> {
+async function listMembers(app: Application, mojangApi: MojangApi, hypixelApi: Client): Promise<Map<string, string[]>> {
   const onlineProfiles: Map<string, string[]> = await getOnlineMembers(app)
 
   for (const [instanceName, members] of onlineProfiles) {
@@ -129,7 +125,7 @@ async function lookupProfiles(
 
   // https://stackoverflow.com/a/8495740
   const chunk = 10
-  for (let index = 0, index_ = usernames.length; index < index_; index += chunk) {
+  for (let index = 0; index < usernames.length; index += chunk) {
     const array = usernames.slice(index, index + chunk)
     mojangRequests.push(
       mojangApi.profilesByUsername(array).catch(() => {

--- a/src/instance/discord/commands/log.ts
+++ b/src/instance/discord/commands/log.ts
@@ -8,7 +8,7 @@ import { escapeDiscord } from '../../../util/shared-util.js'
 import type { CommandInterface } from '../common/command-interface.js'
 import { Permission } from '../common/command-interface.js'
 import { DefaultCommandFooter } from '../common/discord-config.js'
-import { DEFAULT_TIMEOUT, interactivePaging } from '../discord-pager.js'
+import { DefaultTimeout, interactivePaging } from '../discord-pager.js'
 
 const TITLE = 'Guild Log Audit'
 
@@ -85,7 +85,7 @@ export default {
       return
     }
 
-    await interactivePaging(context.interaction, currentPage - 1, DEFAULT_TIMEOUT, async (requestedPage) => {
+    await interactivePaging(context.interaction, currentPage - 1, DefaultTimeout, async (requestedPage) => {
       const chatResult = await getGuildLog(context.application, targetInstanceName, requestedPage + 1)
       return {
         totalPages: chatResult.guildLog?.total ?? 0,

--- a/src/instance/discord/commands/promote.ts
+++ b/src/instance/discord/commands/promote.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from 'discord.js'
 
 import { escapeDiscord } from '../../../util/shared-util.js'
-import { checkChatTriggers, formatChatTriggerResponse, RANK_CHAT } from '../common/chat-triggers.js'
+import { checkChatTriggers, formatChatTriggerResponse, RankChat } from '../common/chat-triggers.js'
 import type { CommandInterface } from '../common/command-interface.js'
 import { Permission } from '../common/command-interface.js'
 
@@ -22,7 +22,7 @@ export default {
     const username: string = context.interaction.options.getString('username', true)
     const command = `/g promote ${username}`
 
-    const result = await checkChatTriggers(context.application, RANK_CHAT, undefined, command, username)
+    const result = await checkChatTriggers(context.application, RankChat, undefined, command, username)
     const formatted = formatChatTriggerResponse(result, `Promote ${escapeDiscord(username)}`)
 
     await context.interaction.editReply({ embeds: [formatted] })

--- a/src/instance/discord/commands/punishments.ts
+++ b/src/instance/discord/commands/punishments.ts
@@ -12,9 +12,9 @@ import { escapeDiscord, getDuration } from '../../../util/shared-util.js'
 import {
   checkChatTriggers,
   formatChatTriggerResponse,
-  KICK_CHAT,
-  MUTE_CHAT,
-  UNMUTE_CHAT
+  KickChat,
+  MuteChat,
+  UnmuteChat
 } from '../common/chat-triggers.js'
 import type { CommandInterface } from '../common/command-interface.js'
 import { Permission } from '../common/command-interface.js'
@@ -194,7 +194,7 @@ async function handleBanAddInteraction(
   application.punishedUsers.punish(event)
   const command = `/guild kick ${username} Banned for ${duration}. Reason: ${reason}`
 
-  const result = await checkChatTriggers(application, KICK_CHAT, undefined, command, username)
+  const result = await checkChatTriggers(application, KickChat, undefined, command, username)
   const formatted = formatChatTriggerResponse(result, `Ban ${escapeDiscord(username)}`)
 
   await interaction.editReply({ embeds: [formatPunishmentAdd(event, noUuidCheck), formatted] })
@@ -232,7 +232,7 @@ async function handleMuteAddInteraction(
   application.punishedUsers.punish(event)
   const command = `/guild mute ${username} ${PunishedUsers.durationToMinecraftDuration(muteDuration)}`
 
-  const result = await checkChatTriggers(application, MUTE_CHAT, undefined, command, username)
+  const result = await checkChatTriggers(application, MuteChat, undefined, command, username)
   const formatted = formatChatTriggerResponse(result, `Mute ${escapeDiscord(username)}`)
 
   application.clusterHelper.sendCommandToAllMinecraft(
@@ -250,7 +250,7 @@ async function handleKickInteraction(
   const reason: string = interaction.options.getString('reason', true)
   const command = `/g kick ${username} ${reason}`
 
-  const result = await checkChatTriggers(application, KICK_CHAT, undefined, command, username)
+  const result = await checkChatTriggers(application, KickChat, undefined, command, username)
   const formatted = formatChatTriggerResponse(result, `Kick ${escapeDiscord(username)}`)
 
   await interaction.editReply({
@@ -303,7 +303,7 @@ async function handleForgiveInteraction(
 
   const command = `/guild unmute ${userResolvedData.userName}`
 
-  const result = await checkChatTriggers(application, UNMUTE_CHAT, undefined, command, username)
+  const result = await checkChatTriggers(application, UnmuteChat, undefined, command, username)
   const formatted = formatChatTriggerResponse(result, `Unmute/Unban ${escapeDiscord(username)}`)
 
   const pages: APIEmbed[] = []
@@ -388,11 +388,11 @@ function formatList(list: PunishmentAddEvent[]): APIEmbed[] {
 
   const pages = []
 
-  const MAX_LENGTH = 3900
+  const MaxLength = 3900
   let currentLength = 0
   let entriesCount = 0
   for (const entry of entries) {
-    if (pages.length === 0 || currentLength + entry.length > MAX_LENGTH || entriesCount >= 20) {
+    if (pages.length === 0 || currentLength + entry.length > MaxLength || entriesCount >= 20) {
       currentLength = 0
       entriesCount = 0
 

--- a/src/instance/discord/commands/setrank.ts
+++ b/src/instance/discord/commands/setrank.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from 'discord.js'
 
 import { escapeDiscord } from '../../../util/shared-util.js'
-import { checkChatTriggers, formatChatTriggerResponse, RANK_CHAT } from '../common/chat-triggers.js'
+import { checkChatTriggers, formatChatTriggerResponse, RankChat } from '../common/chat-triggers.js'
 import type { CommandInterface } from '../common/command-interface.js'
 import { Permission } from '../common/command-interface.js'
 
@@ -26,7 +26,7 @@ export default {
     const rank: string = context.interaction.options.getString('rank', true)
 
     const command = `/g setrank ${username} ${rank}`
-    const result = await checkChatTriggers(context.application, RANK_CHAT, undefined, command, username)
+    const result = await checkChatTriggers(context.application, RankChat, undefined, command, username)
     const formatted = formatChatTriggerResponse(result, `Setrank ${escapeDiscord(username)}`)
 
     await context.interaction.editReply({ embeds: [formatted] })

--- a/src/instance/discord/common/chat-triggers.ts
+++ b/src/instance/discord/common/chat-triggers.ts
@@ -12,7 +12,7 @@ export interface RegexChat {
   failure: RegExp[]
 }
 
-const GENERAL_CHAT: RegexChat = {
+const GeneralChat: RegexChat = {
   success: [],
   failure: [
     /^Can't find a player by the name of '(\w{3,32})'*/,
@@ -23,14 +23,14 @@ const GENERAL_CHAT: RegexChat = {
   ]
 }
 
-export const RANK_CHAT: RegexChat = {
+export const RankChat: RegexChat = {
   success: [
-    ...GENERAL_CHAT.success,
+    ...GeneralChat.success,
     /^(?:\[[+A-Z]{1,10}] )*(\w{3,32}) was promoted from.*/,
     /^(?:\[[+A-Z]{1,10}] )*(\w{3,32}) was demoted from.*/
   ],
   failure: [
-    ...GENERAL_CHAT.failure,
+    ...GeneralChat.failure,
     /^I couldn't find a rank by the name of.*/,
     /^You can only promote up to your own rank.*/,
     /^You can only demote up to your own rank.*/,
@@ -40,13 +40,13 @@ export const RANK_CHAT: RegexChat = {
   ]
 }
 
-export const KICK_CHAT: RegexChat = {
+export const KickChat: RegexChat = {
   success: [
-    ...GENERAL_CHAT.success,
+    ...GeneralChat.success,
     /^(?:\[[+A-Z]{1,10}] )*(\w{3,32}) was kicked from the guild by (?:\[[+A-Z]{1,10}] )*(\w{3,32})!/
   ],
   failure: [
-    ...GENERAL_CHAT.failure,
+    ...GeneralChat.failure,
     /^Invalid usage! '\/guild kick <player> <reason>'/,
     /^You cannot kick yourself from the guild!/,
     /^You do not have permission to kick people from the guild!/,
@@ -54,13 +54,13 @@ export const KICK_CHAT: RegexChat = {
   ]
 }
 
-export const MUTE_CHAT: RegexChat = {
+export const MuteChat: RegexChat = {
   success: [
-    ...GENERAL_CHAT.success,
+    ...GeneralChat.success,
     /^(?:\[[+A-Z]{1,10}] )*\w{3,32} has muted (?:\[[+A-Z]{1,10}] )*(\w{3,32}|the guild chat) for.*/
   ],
   failure: [
-    ...GENERAL_CHAT.failure,
+    ...GeneralChat.failure,
     /^Invalid usage! '\/guild mute <player\/everyone> <time>'/,
     /^You cannot mute someone for more than one month/,
     /^You cannot mute someone for less than a minute/,
@@ -69,29 +69,29 @@ export const MUTE_CHAT: RegexChat = {
   ]
 }
 
-export const UNMUTE_CHAT: RegexChat = {
+export const UnmuteChat: RegexChat = {
   success: [
-    ...GENERAL_CHAT.success,
+    ...GeneralChat.success,
     /^(?:\[[+A-Z]{1,10}] )*\w{3,32} has unmuted (?:\[[+A-Z]{1,10}] )*(\w{3,32}|the guild chat).*/
   ],
   failure: [
-    ...GENERAL_CHAT.failure,
+    ...GeneralChat.failure,
     /^Invalid usage! '\/guild unmute <player\/everyone>'/,
     /^This player is not muted!/,
     /^The guild is not muted!/
   ]
 }
 
-export const INVITE_ACCEPT_CHAT: RegexChat = {
+export const InviteAcceptChat: RegexChat = {
   success: [
-    ...GENERAL_CHAT.success,
+    ...GeneralChat.success,
     /^You invited (?:\[[+A-Z]{1,10}] )*(\w{3,32}) to your guild. They have 5 minutes to accept/,
     /^You sent an offline invite to (?:\[[+A-Z]{1,10}] )*(\w{3,32})! They will have 5 minutes to accept once they come online!/,
     /^You've already invited (?:\[[+A-Z]{1,10}] )*(\w{3,32}) to your guild! Wait for them to accept!/,
     /^(?:\[[+A-Z]{1,10}] )*(\w{3,32}) joined the guild!/
   ],
   failure: [
-    ...GENERAL_CHAT.failure,
+    ...GeneralChat.failure,
     /^You do not have permission to invite players!/,
     /^You cannot invite this player to your guild!/,
     /^(?:\[[+A-Z]{1,10}] )*(\w{3,32}) is already in another guild!/,

--- a/src/instance/discord/discord-instance.ts
+++ b/src/instance/discord/discord-instance.ts
@@ -107,10 +107,10 @@ export default class DiscordInstance extends ClientInstance<DiscordConfig> {
       return
     }
 
-    for (const _channelId of channels) {
-      if (_channelId === event.channelId) continue
+    for (const channelId of channels) {
+      if (channelId === event.channelId) continue
 
-      const webhook = await this.getWebhook(_channelId)
+      const webhook = await this.getWebhook(channelId)
       const displayUsername =
         event.replyUsername == undefined ? event.username : `${event.username}⇾${event.replyUsername}`
 

--- a/src/instance/discord/discord-pager.ts
+++ b/src/instance/discord/discord-pager.ts
@@ -17,9 +17,9 @@ enum Button {
   BACK = 'back'
 }
 
-export const DEFAULT_TIMEOUT = 60_000
+export const DefaultTimeout = 60_000
 
-const NO_EMBED: APIEmbed = {
+const NoEmbed: APIEmbed = {
   color: Severity.ERROR,
   title: 'Nothing to display',
   description:
@@ -36,14 +36,14 @@ const NO_EMBED: APIEmbed = {
 export async function interactivePaging(
   interaction: CommandInteraction,
   currentPage = 0,
-  duration = DEFAULT_TIMEOUT,
+  duration = DefaultTimeout,
   fetch: (page: number) => Promise<FetchPageResult> | FetchPageResult
 ): Promise<Message> {
   const channel: TextBasedChannel = interaction.channel as TextChannel
   let lastUpdate = await fetch(currentPage)
 
   if (lastUpdate.embed === undefined) {
-    return await interaction.editReply({ embeds: [NO_EMBED] })
+    return await interaction.editReply({ embeds: [NoEmbed] })
   }
 
   if (lastUpdate.totalPages > 1) {
@@ -60,7 +60,7 @@ export async function interactivePaging(
       void index.deferUpdate().then(async () => {
         lastUpdate = await fetch(++currentPage)
         if (lastUpdate.embed === undefined) {
-          await interaction.editReply({ embeds: [NO_EMBED] })
+          await interaction.editReply({ embeds: [NoEmbed] })
           return
         }
 
@@ -74,7 +74,7 @@ export async function interactivePaging(
       void index.deferUpdate().then(async () => {
         lastUpdate = await fetch(--currentPage)
         if (lastUpdate.embed === undefined) {
-          await interaction.editReply({ embeds: [NO_EMBED] })
+          await interaction.editReply({ embeds: [NoEmbed] })
           return
         }
 
@@ -87,7 +87,7 @@ export async function interactivePaging(
 
     nextInteraction.on('end', () => {
       if (lastUpdate.embed === undefined) {
-        void interaction.editReply({ embeds: [NO_EMBED] })
+        void interaction.editReply({ embeds: [NoEmbed] })
         return
       }
 
@@ -107,7 +107,7 @@ export async function interactivePaging(
 export async function pageMessage(
   interaction: CommandInteraction,
   pages: APIEmbed[],
-  duration = DEFAULT_TIMEOUT
+  duration = DefaultTimeout
 ): Promise<Message> {
   return await interactivePaging(interaction, 0, duration, (page) => {
     return { embed: pages[page], totalPages: pages.length }

--- a/src/instance/minecraft/chat-manager.ts
+++ b/src/instance/minecraft/chat-manager.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 
-import getMinecraftData from 'minecraft-data'
+import GetMinecraftData from 'minecraft-data'
 import type { ChatMessage } from 'prismarine-chat'
 
 import { InstanceType } from '../../common/application-event.js'
@@ -57,7 +57,7 @@ export default class ChatManager extends EventHandler<MinecraftInstance> {
     assert(this.clientInstance.registry)
 
     const prismChat = this.clientInstance.prismChat
-    const minecraftData = getMinecraftData(this.clientInstance.client.version)
+    const minecraftData = GetMinecraftData(this.clientInstance.client.version)
 
     this.clientInstance.client.on('systemChat', (data) => {
       const chatMessage = prismChat.fromNotch(data.formattedMessage)

--- a/src/instance/minecraft/handlers/state-handler.ts
+++ b/src/instance/minecraft/handlers/state-handler.ts
@@ -3,7 +3,7 @@ import { Status } from '../../../common/client-instance.js'
 import EventHandler from '../../../common/event-handler.js'
 import type MinecraftInstance from '../minecraft-instance.js'
 
-export const QUIT_OWN_VOLITION = 'disconnect.quitting'
+export const QuitOwnVolition = 'disconnect.quitting'
 
 export default class StateHandler extends EventHandler<MinecraftInstance> {
   private loginAttempts
@@ -75,7 +75,7 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
         message: reason
       })
       return
-    } else if (reason === QUIT_OWN_VOLITION) {
+    } else if (reason === QuitOwnVolition) {
       const reason = 'Client quit on its own volition. No further trying to reconnect.'
 
       this.clientInstance.logger.debug(reason)

--- a/src/instance/minecraft/minecraft-instance.ts
+++ b/src/instance/minecraft/minecraft-instance.ts
@@ -17,9 +17,9 @@ import { resolveProxyIfExist } from './common/proxy-handler.js'
 import ErrorHandler from './handlers/error-handler.js'
 import SelfbroadcastHandler from './handlers/selfbroadcast-handler.js'
 import SendchatHandler from './handlers/sendchat-handler.js'
-import StateHandler, { QUIT_OWN_VOLITION } from './handlers/state-handler.js'
+import StateHandler, { QuitOwnVolition } from './handlers/state-handler.js'
 
-const commandsLimiter = new RateLimiter(1, 1000)
+const CommandsLimiter = new RateLimiter(1, 1000)
 
 export default class MinecraftInstance extends ClientInstance<MinecraftInstanceConfig> {
   defaultBotConfig = {
@@ -111,7 +111,7 @@ export default class MinecraftInstance extends ClientInstance<MinecraftInstanceC
   }
 
   connect(): void {
-    this.client?.end(QUIT_OWN_VOLITION)
+    this.client?.end(QuitOwnVolition)
 
     this.client = createClient({
       ...this.defaultBotConfig,
@@ -181,7 +181,7 @@ export default class MinecraftInstance extends ClientInstance<MinecraftInstanceC
       .join(' ')
 
     this.logger.debug(`Queuing message to send: ${message}`)
-    await commandsLimiter.wait().then(() => {
+    await CommandsLimiter.wait().then(() => {
       if (this.client?.state === states.PLAY) {
         if (message.length > 250) {
           message = message.slice(0, 250) + '...'

--- a/src/plugins/auto-restart-plugin.ts
+++ b/src/plugins/auto-restart-plugin.ts
@@ -8,8 +8,8 @@ THIS PLUGIN IS NOT ESSENTIAL BUT IS HEAVILY RECOMMENDED.
 BRIDGE WILL USE MORE RAM THE LONGER IT IS LEFT WITHOUT RESTARTING
 */
 
-const MAX_LIFE_TILL_RESTART = 24 * 60 * 60 // 24 hour in seconds
-const CHECK_EVERY = 5 * 60 * 1000 // 5 minutes in milliseconds
+const MaxLifeTillRestart = 24 * 60 * 60 // 24 hour in seconds
+const CheckEvery = 5 * 60 * 1000 // 5 minutes in milliseconds
 
 export default {
   onRun(context: PluginContext): void {
@@ -18,7 +18,7 @@ export default {
     setInterval(() => {
       if (shuttingDown) return
 
-      if (MAX_LIFE_TILL_RESTART < uptime()) {
+      if (MaxLifeTillRestart < uptime()) {
         shuttingDown = true
 
         context.application.emit('event', {
@@ -42,6 +42,6 @@ export default {
           targetInstanceName: undefined
         })
       }
-    }, CHECK_EVERY)
+    }, CheckEvery)
   }
 } satisfies PluginInterface

--- a/src/plugins/starfall-cult-plugin.ts
+++ b/src/plugins/starfall-cult-plugin.ts
@@ -34,13 +34,13 @@ export default {
 } satisfies PluginInterface
 
 function getSkyblockTime(): { day: number } {
-  const HOUR_MS = 50_000
-  const DAY_MS = 24 * HOUR_MS
-  const MONTH_MS = 31 * DAY_MS
-  const YEAR_0 = 1_560_275_700_000
+  const HourInMillisecond = 50_000
+  const DayInMilliseconds = 24 * HourInMillisecond
+  const MonthInMillisecond = 31 * DayInMilliseconds
+  const Year0 = 1_560_275_700_000
 
-  const currentEpoch = Date.now() - YEAR_0
-  const day = (currentEpoch % MONTH_MS) / DAY_MS + 1
+  const currentEpoch = Date.now() - Year0
+  const day = (currentEpoch % MonthInMillisecond) / DayInMilliseconds + 1
   return {
     day: Math.floor(day)
   }

--- a/src/plugins/warp-plugin.ts
+++ b/src/plugins/warp-plugin.ts
@@ -138,7 +138,7 @@ async function awaitPartyStatus(
 }
 
 class WarpCommand extends ChatCommandHandler {
-  private static readonly commandCoolDown = 60_000
+  private static readonly CommandCoolDown = 60_000
   private lastCommandExecutionAt = 0
   private readonly minecraftInstances: MinecraftInstance[]
 
@@ -159,8 +159,8 @@ class WarpCommand extends ChatCommandHandler {
     }
 
     const currentTime = Date.now()
-    if (this.lastCommandExecutionAt + WarpCommand.commandCoolDown > currentTime) {
-      return `Can use command again in ${Math.floor((this.lastCommandExecutionAt + WarpCommand.commandCoolDown - currentTime) / 1000)} seconds.`
+    if (this.lastCommandExecutionAt + WarpCommand.CommandCoolDown > currentTime) {
+      return `Can use command again in ${Math.floor((this.lastCommandExecutionAt + WarpCommand.CommandCoolDown - currentTime) / 1000)} seconds.`
     }
 
     const username = context.args[0]

--- a/src/types/hypixel-api-reborn.d.ts
+++ b/src/types/hypixel-api-reborn.d.ts
@@ -1,5 +1,7 @@
 import type { skyblockMemberOptions } from 'hypixel-api-reborn'
 
+// public api interfaces. Can't choose a naming convention
+/* eslint-disable @typescript-eslint/naming-convention */
 declare module 'hypixel-api-reborn' {
   interface Client {
     getSkyblockProfiles(
@@ -92,3 +94,4 @@ declare module 'hypixel-api-reborn' {
     boss_kills_tier_4?: number
   }
 }
+/* eslint-enable @typescript-eslint/naming-convention */

--- a/src/util/mojang.ts
+++ b/src/util/mojang.ts
@@ -1,5 +1,5 @@
 import type { AxiosResponse } from 'axios'
-import axios from 'axios'
+import Axios from 'axios'
 import NodeCache from 'node-cache'
 
 export class MojangApi {
@@ -9,9 +9,9 @@ export class MojangApi {
     const cachedResult = this.cache.get<MojangProfile>(username.toLowerCase())
     if (cachedResult) return cachedResult
 
-    const result = await axios
-      .get(`https://api.mojang.com/users/profiles/minecraft/${username}`)
-      .then((response: AxiosResponse<MojangProfile, unknown>) => response.data)
+    const result = await Axios.get(`https://api.mojang.com/users/profiles/minecraft/${username}`).then(
+      (response: AxiosResponse<MojangProfile, unknown>) => response.data
+    )
 
     this.cache.set<MojangProfile>(result.name.toLowerCase(), result)
     return result
@@ -28,9 +28,9 @@ export class MojangApi {
 
     if (leftUsernames.length === 0) return partialResult
 
-    const result = await axios
-      .post(`https://api.mojang.com/profiles/minecraft`, leftUsernames)
-      .then((response: AxiosResponse<MojangProfile[], unknown>) => response.data)
+    const result = await Axios.post(`https://api.mojang.com/profiles/minecraft`, leftUsernames).then(
+      (response: AxiosResponse<MojangProfile[], unknown>) => response.data
+    )
 
     for (const mojangProfile of result) {
       this.cache.set<MojangProfile>(mojangProfile.name.toLowerCase(), mojangProfile)

--- a/src/util/punished-users.ts
+++ b/src/util/punished-users.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 
-import * as t from 'ts-interface-checker'
+import * as TypescriptChecker from 'ts-interface-checker'
 import { createCheckers } from 'ts-interface-checker'
 
 import type Application from '../application.js'
@@ -10,12 +10,16 @@ import { PunishmentType } from '../common/application-event.js'
 
 import type { MojangApi } from './mojang.js'
 
-const applicationEventChecker = createCheckers({ ...ApplicationEventTi, PunishmentList: t.array('PunishmentAddEvent') })
+const ApplicationEventChecker = createCheckers({
+  ...ApplicationEventTi,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  PunishmentList: TypescriptChecker.array('PunishmentAddEvent')
+})
 
 type PunishmentsRecord = Record<PunishmentType, PunishmentAddEvent[]>
 
 export class PunishedUsers {
-  private static readonly CONFIG_NAME = 'punishments.json'
+  private static readonly ConfigName = 'punishments.json'
   private readonly app: Application
   private readonly configFilePath: string
   private punishmentsRecord: PunishmentsRecord = {
@@ -25,7 +29,7 @@ export class PunishedUsers {
 
   constructor(app: Application) {
     this.app = app
-    this.configFilePath = app.getConfigFilePath(PunishedUsers.CONFIG_NAME)
+    this.configFilePath = app.getConfigFilePath(PunishedUsers.ConfigName)
     this.loadFromConfig()
 
     app.on('punishmentAdd', (event) => {
@@ -129,13 +133,13 @@ export class PunishedUsers {
   static durationToMinecraftDuration(duration: number): string {
     // 30 day in seconds
     // Max allowed duration in minecraft. It is a hard limit from server side
-    const MAX_DURATION = 2_592_000
+    const MaxDuration = 2_592_000
     // 1 minute in seconds. hard limit too
-    const MIN_DURATION = 60
-    const PREFIX = 's' // for "seconds"
+    const MixDuration = 60
+    const Prefix = 's' // for "seconds"
 
-    const max_time = Math.min(MAX_DURATION, Math.floor(duration / 1000))
-    return `${Math.max(max_time, MIN_DURATION)}${PREFIX}`
+    const maxTime = Math.min(MaxDuration, Math.floor(duration / 1000))
+    return `${Math.max(maxTime, MixDuration)}${Prefix}`
   }
 
   private loadFromConfig(): void {
@@ -145,8 +149,8 @@ export class PunishedUsers {
     const punishmentsRecord = JSON.parse(fileData) as PunishmentsRecord
 
     for (const [type, punishments] of Object.entries(punishmentsRecord)) {
-      applicationEventChecker.PunishmentType.check(type)
-      applicationEventChecker.PunishmentList.check(punishments)
+      ApplicationEventChecker.PunishmentType.check(type)
+      ApplicationEventChecker.PunishmentList.check(punishments)
     }
 
     this.punishmentsRecord = punishmentsRecord

--- a/src/util/shared-util.ts
+++ b/src/util/shared-util.ts
@@ -1,4 +1,4 @@
-import log4js from 'log4js'
+import Logger4js from 'log4js'
 
 export function sufficeToTime(suffice: string): number {
   suffice = suffice.toLowerCase().trim()
@@ -48,12 +48,12 @@ export function shutdownApplication(exitCode: number): void {
   })
 
   // eslint-disable-next-line import/no-named-as-default-member
-  log4js.shutdown(() => {
+  Logger4js.shutdown(() => {
     process.exit(exitCode)
   })
 }
 
-export const escapeDiscord = function (message: string): string {
+export function escapeDiscord(message: string): string {
   message = message.split('\\').join('\\\\') // "\"
   message = message.split('_').join(String.raw`\_`) // Italic
   message = message.split('*').join(String.raw`\*`) // bold


### PR DESCRIPTION
Chosen naming convention:
- classes/interfaces/enum/etc declarations PascalCase
- enum members PascalCase
- variables/functions/members are camelCase
- variables inside code block camelCase
- magic value variable inside code block PascalCase
- const variable globally PascalCase

Trying to make magic values PascalCase while enforcing other variables to be camelCase has proven to be hard