### PR TITLE
fix(commands): Commands crashes

### DIFF
--- a/src/instance/commands/commands-instance.ts
+++ b/src/instance/commands/commands-instance.ts
@@ -109,34 +109,51 @@ export class CommandsInstance extends ClientInstance<CommandsConfig> {
       return
     }
 
-    const commandResponse = await command.handler({
-      app: this.app,
+    try {
+      const commandResponse = await command.handler({
+        app: this.app,
 
-      logger: this.logger,
-      allCommands: this.commands,
-      commandPrefix: this.config.commandPrefix,
-      adminUsername: this.config.adminUsername,
+        logger: this.logger,
+        allCommands: this.commands,
+        commandPrefix: this.config.commandPrefix,
+        adminUsername: this.config.adminUsername,
 
-      instanceName: event.instanceName,
-      instanceType: event.instanceType,
-      channelType: event.channelType,
+        instanceName: event.instanceName,
+        instanceType: event.instanceType,
+        channelType: event.channelType,
 
-      username: event.username,
-      isAdmin: isAdmin,
-      args: commandsArguments
-    })
+        username: event.username,
+        isAdmin: isAdmin,
+        args: commandsArguments
+      })
 
-    this.app.emit('command', {
-      localEvent: true,
-      instanceName: event.instanceName,
-      instanceType: event.instanceType,
-      channelType: event.channelType,
-      discordChannelId: event.channelId,
-      username: event.username,
-      fullCommand: event.message,
-      commandName: command.triggers[0],
-      commandResponse: commandResponse,
-      alreadyReplied: false
-    })
+      this.app.emit('command', {
+        localEvent: true,
+        instanceName: event.instanceName,
+        instanceType: event.instanceType,
+        channelType: event.channelType,
+        discordChannelId: event.channelId,
+        username: event.username,
+        fullCommand: event.message,
+        commandName: command.triggers[0],
+        commandResponse: commandResponse,
+        alreadyReplied: false
+      })
+    } catch (error) {
+      this.logger.error('Error while handling command', error)
+
+      this.app.emit('command', {
+        localEvent: true,
+        instanceName: event.instanceName,
+        instanceType: event.instanceType,
+        channelType: event.channelType,
+        discordChannelId: event.channelId,
+        username: event.username,
+        fullCommand: event.message,
+        commandName: command.triggers[0],
+        commandResponse: `${event.username}, error trying to execute ${command.triggers[0]}.`,
+        alreadyReplied: false
+      })
+    }
   }
 }

--- a/src/instance/commands/common/util.ts
+++ b/src/instance/commands/common/util.ts
@@ -15,15 +15,18 @@ export async function getUuidIfExists(mojangApi: MojangApi, username: string): P
   return result || undefined
 }
 
-export async function getSelectedSkyblockProfileRaw(hypixelApi: Client, uuid: string): Promise<SkyblockV2Member> {
-  return await hypixelApi
-    .getSkyblockProfiles(uuid, { raw: true })
-    .then((response) => response.profiles.find((p) => p.selected))
-    .then((profiles) => profiles?.members[uuid])
-    .then((profile) => {
-      assert(profile)
-      return profile
-    })
+export async function getSelectedSkyblockProfileRaw(
+  hypixelApi: Client,
+  uuid: string
+): Promise<SkyblockV2Member | undefined> {
+  const response = await hypixelApi.getSkyblockProfiles(uuid, { raw: true })
+
+  if (!response.profiles) return undefined
+  const profile = response.profiles.find((p) => p.selected)
+
+  const selected = profile?.members[uuid]
+  assert(selected)
+  return selected
 }
 
 export async function getSelectedSkyblockProfile(hypixelApi: Client, uuid: string): Promise<SkyblockMember> {
@@ -67,4 +70,16 @@ export function getDungeonLevelWithOverflow(experience: number): number {
 
   const fractionLevel = remainingXP / DungeonXp[totalLevel]
   return totalLevel + fractionLevel
+}
+
+export function usernameNotExists(givenUsername: string): string {
+  return `Invalid username! (given: ${givenUsername})`
+}
+
+export function playerNeverPlayedSkyblock(username: string): string {
+  return `${username} has never played skyblock before?`
+}
+
+export function playerNeverPlayedDungeons(username: string): string {
+  return `${username} has never played dungeons before?`
 }

--- a/src/instance/commands/common/util.ts
+++ b/src/instance/commands/common/util.ts
@@ -83,3 +83,7 @@ export function playerNeverPlayedSkyblock(username: string): string {
 export function playerNeverPlayedDungeons(username: string): string {
   return `${username} has never played dungeons before?`
 }
+
+export function playerNeverPlayedSlayers(username: string): string {
+  return `${username} has never done slayers before?`
+}

--- a/src/instance/commands/triggers/bits.ts
+++ b/src/instance/commands/triggers/bits.ts
@@ -78,7 +78,11 @@ export default class Bits extends ChatCommandHandler {
   async handler(context: ChatCommandContext): Promise<string> {
     const currentTime = Date.now()
     if (this.lastPricesUpdateAt + Bits.UpdatePriceEvery < currentTime) {
-      await this.updatePrices()
+      try {
+        await this.updatePrices()
+      } catch {
+        return `${context.username}, cannot update prices.`
+      }
       this.lastPricesUpdateAt = currentTime
     }
 

--- a/src/instance/commands/triggers/calculate.ts
+++ b/src/instance/commands/triggers/calculate.ts
@@ -27,14 +27,18 @@ export default class Calculate extends ChatCommandHandler {
       .replaceAll('x', '*') // x is also used for multiplication
       .replaceAll(',', '') // removes commas from numbers
 
-    const result = evalExpression(expression)
+    try {
+      const result = evalExpression(expression)
 
-    // The following if-statement is purely an Easter egg
-    // It can be removed without causing any adverse affects on the bridge
-    if (result <= 50 && result >= -50 && Math.random() < 0.2) {
-      return `${context.username} haiyaaaaaaaaa this is so easy, you're a disappointment *takes off slipper* (answer: ${result.toLocaleString()})`
+      // The following if-statement is purely an Easter egg
+      // It can be removed without causing any adverse affects on the bridge
+      if (result <= 50 && result >= -50 && Math.random() < 0.2) {
+        return `${context.username} haiyaaaaaaaaa this is so easy, you're a disappointment *takes off slipper* (answer: ${result.toLocaleString()})`
+      }
+
+      return `${context.username}, answer: ${result.toLocaleString()}`
+    } catch {
+      return `${context.username}, invalid math expression`
     }
-
-    return `${context.username}, answer: ${result.toLocaleString()}`
   }
 }

--- a/src/instance/commands/triggers/catacomb.ts
+++ b/src/instance/commands/triggers/catacomb.ts
@@ -2,7 +2,14 @@ import type { SkyblockV2Dungeons } from 'hypixel-api-reborn'
 
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
-import { getDungeonLevelWithOverflow, getSelectedSkyblockProfileRaw, getUuidIfExists } from '../common/util.js'
+import {
+  getDungeonLevelWithOverflow,
+  getSelectedSkyblockProfileRaw,
+  getUuidIfExists,
+  playerNeverPlayedDungeons,
+  playerNeverPlayedSkyblock,
+  usernameNotExists
+} from '../common/util.js'
 
 export default class Catacomb extends ChatCommandHandler {
   constructor() {
@@ -18,12 +25,16 @@ export default class Catacomb extends ChatCommandHandler {
     const givenUsername = context.args[0] ?? context.username
 
     const uuid = await getUuidIfExists(context.app.mojangApi, givenUsername)
-    if (uuid == undefined) {
-      return `No such username! (given: ${givenUsername})`
+    if (uuid == undefined) return usernameNotExists(givenUsername)
+
+    const selectedProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
+    if (!selectedProfile) return playerNeverPlayedSkyblock(givenUsername)
+
+    const dungeons = selectedProfile.dungeons
+    if (!dungeons) {
+      return playerNeverPlayedDungeons(givenUsername)
     }
 
-    const parsedProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
-    const dungeons = parsedProfile.dungeons
     const skillLevel = getDungeonLevelWithOverflow(dungeons.dungeon_types.catacombs.experience)
 
     return `${givenUsername} is Catacombs ${skillLevel.toFixed(2)} ${this.formatClass(dungeons)}.`

--- a/src/instance/commands/triggers/guild.ts
+++ b/src/instance/commands/triggers/guild.ts
@@ -6,6 +6,7 @@
 
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
+import { getUuidIfExists, usernameNotExists } from '../common/util.js'
 
 export default class Guild extends ChatCommandHandler {
   constructor() {
@@ -20,16 +21,8 @@ export default class Guild extends ChatCommandHandler {
   async handler(context: ChatCommandContext): Promise<string> {
     const givenUsername = context.args[0] ?? context.username
 
-    const uuid = await context.app.mojangApi
-      .profileByUsername(givenUsername)
-      .then((p) => p.id)
-      .catch(() => {
-        /* return undefined */
-      })
-
-    if (uuid == undefined) {
-      return `No such username! (given: ${givenUsername})`
-    }
+    const uuid = await getUuidIfExists(context.app.mojangApi, givenUsername)
+    if (uuid == undefined) return usernameNotExists(givenUsername)
 
     const guild = await context.app.hypixelApi.getGuild('player', uuid, {}).catch(() => {
       /* return undefined */

--- a/src/instance/commands/triggers/level.ts
+++ b/src/instance/commands/triggers/level.ts
@@ -1,6 +1,11 @@
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
-import { getSelectedSkyblockProfileRaw, getUuidIfExists } from '../common/util.js'
+import {
+  getSelectedSkyblockProfileRaw,
+  getUuidIfExists,
+  playerNeverPlayedSkyblock,
+  usernameNotExists
+} from '../common/util.js'
 
 export default class Level extends ChatCommandHandler {
   constructor() {
@@ -16,12 +21,12 @@ export default class Level extends ChatCommandHandler {
     const givenUsername = context.args[0] ?? context.username
 
     const uuid = await getUuidIfExists(context.app.mojangApi, givenUsername)
-    if (uuid == undefined) {
-      return `No such username! (given: ${givenUsername})`
-    }
+    if (uuid == undefined) return usernameNotExists(givenUsername)
 
-    const profile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
-    const exp = profile.leveling?.experience ?? 0
+    const selectedProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
+    if (!selectedProfile) return playerNeverPlayedSkyblock(givenUsername)
+
+    const exp = selectedProfile.leveling?.experience ?? 0
     return `${givenUsername}'s level: ${(exp / 100).toFixed(2)}`
   }
 }

--- a/src/instance/commands/triggers/networth.ts
+++ b/src/instance/commands/triggers/networth.ts
@@ -45,13 +45,18 @@ export default class Networth extends ChatCommandHandler {
     )
       .then((response: AxiosResponse<HypixelSkyblockMuseumRaw, unknown>) => response.data)
       .then((museum) => museum.members[uuid] as object)
+      .catch(() => undefined)
+    if (museumData === undefined) return `${context.username}, player doesn't have museum?`
 
     const networth = await getNetworth(selectedProfile.members[uuid], selectedProfile.banking?.balance ?? 0, {
       v2Endpoint: true,
       prices: this.prices,
       museumData: museumData,
       onlyNetworth: true
-    }).then((response) => response.networth)
+    })
+      .then((response) => response.networth)
+      .catch(() => undefined)
+    if (networth === undefined) return `${context.username}, cannot calculate the network?`
 
     return `${givenUsername}'s networth: ${this.localizedNetworth(networth)}`
   }

--- a/src/instance/commands/triggers/runs-to-class-average.ts
+++ b/src/instance/commands/triggers/runs-to-class-average.ts
@@ -2,7 +2,14 @@ import assert from 'node:assert'
 
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
-import { getDungeonLevelWithOverflow, getUuidIfExists } from '../common/util.js'
+import {
+  getDungeonLevelWithOverflow,
+  getSelectedSkyblockProfileRaw,
+  getUuidIfExists,
+  playerNeverPlayedDungeons,
+  playerNeverPlayedSkyblock,
+  usernameNotExists
+} from '../common/util.js'
 
 const FloorsBaseExp = {
   m6: 105_000,
@@ -26,30 +33,24 @@ export default class RunsToClassAverage extends ChatCommandHandler {
     const targetAverage = context.args[1] ? Number.parseInt(context.args[1], 10) : 50
 
     const uuid = await getUuidIfExists(context.app.mojangApi, givenUsername)
-    if (uuid == undefined) {
-      return `No such username! (given: ${givenUsername})`
-    }
+    if (uuid == undefined) return usernameNotExists(givenUsername)
 
     const selectedFloor = 'm7'.toLowerCase()
-    if (!(selectedFloor in FloorsBaseExp)) {
-      return `Invalid floor selected: ${selectedFloor}`
-    }
+    if (!(selectedFloor in FloorsBaseExp)) return `Invalid floor selected: ${selectedFloor}`
     const xpPerRun = FloorsBaseExp[selectedFloor as keyof typeof FloorsBaseExp]
 
-    const parsedProfile = await context.app.hypixelApi
-      .getSkyblockProfiles(uuid, { raw: true })
-      .then((response) => response.profiles.find((p) => p.selected)?.members[uuid])
-    assert(parsedProfile)
+    const selectedProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
+    if (!selectedProfile) return playerNeverPlayedSkyblock(givenUsername)
 
-    if (parsedProfile.dungeons.player_classes === undefined) {
-      return `${givenUsername} never played dungeons before?`
+    if (selectedProfile.dungeons?.player_classes === undefined) {
+      return playerNeverPlayedDungeons(givenUsername)
     }
 
-    const heartOfGold = parsedProfile.essence?.perks?.heart_of_gold ?? 0
-    const unbridledRage = parsedProfile.essence?.perks?.unbridled_rage ?? 0
-    const coldEfficiency = parsedProfile.essence?.perks?.cold_efficiency ?? 0
-    const toxophilite = parsedProfile.essence?.perks?.toxophilite ?? 0
-    const diamondInTheRough = parsedProfile.essence?.perks?.diamond_in_the_rough ?? 0
+    const heartOfGold = selectedProfile.essence?.perks?.heart_of_gold ?? 0
+    const unbridledRage = selectedProfile.essence?.perks?.unbridled_rage ?? 0
+    const coldEfficiency = selectedProfile.essence?.perks?.cold_efficiency ?? 0
+    const toxophilite = selectedProfile.essence?.perks?.toxophilite ?? 0
+    const diamondInTheRough = selectedProfile.essence?.perks?.diamond_in_the_rough ?? 0
 
     const classExpBoosts = {
       healer: (heartOfGold * 2) / 100 + 1,
@@ -75,7 +76,7 @@ export default class RunsToClassAverage extends ChatCommandHandler {
       tank: 0
     } as Record<ClassName, number>
 
-    for (const [className, classObject] of Object.entries(parsedProfile.dungeons.player_classes)) {
+    for (const [className, classObject] of Object.entries(selectedProfile.dungeons.player_classes)) {
       classesExperiences[className as ClassName] = classObject?.experience ?? 0
     }
 

--- a/src/instance/commands/triggers/runs.ts
+++ b/src/instance/commands/triggers/runs.ts
@@ -1,6 +1,12 @@
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
-import { getSelectedSkyblockProfileRaw, getUuidIfExists } from '../common/util.js'
+import {
+  getSelectedSkyblockProfileRaw,
+  getUuidIfExists,
+  playerNeverPlayedDungeons,
+  playerNeverPlayedSkyblock,
+  usernameNotExists
+} from '../common/util.js'
 
 export default class Runs extends ChatCommandHandler {
   constructor() {
@@ -26,12 +32,15 @@ export default class Runs extends ChatCommandHandler {
     }
 
     const uuid = await getUuidIfExists(context.app.mojangApi, givenUsername)
-    if (uuid == undefined) {
-      return `${context.username}, Invalid username! (given: ${givenUsername})`
-    }
+    if (uuid == undefined) return usernameNotExists(givenUsername)
 
-    const parsedProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
-    const dungeon = parsedProfile.dungeons.dungeon_types
+    const selectedProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
+    if (!selectedProfile) return playerNeverPlayedSkyblock(givenUsername)
+
+    const dungeon = selectedProfile.dungeons?.dungeon_types
+    if (!dungeon) {
+      return playerNeverPlayedDungeons(givenUsername)
+    }
 
     const runs = masterMode
       ? this.getTotalRuns(dungeon.master_catacombs.tier_completions)

--- a/src/instance/commands/triggers/secrets.ts
+++ b/src/instance/commands/triggers/secrets.ts
@@ -1,6 +1,12 @@
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
-import { getSelectedSkyblockProfileRaw, getUuidIfExists } from '../common/util.js'
+import {
+  getSelectedSkyblockProfileRaw,
+  getUuidIfExists,
+  playerNeverPlayedDungeons,
+  playerNeverPlayedSkyblock,
+  usernameNotExists
+} from '../common/util.js'
 
 export default class Secrets extends ChatCommandHandler {
   constructor() {
@@ -15,15 +21,17 @@ export default class Secrets extends ChatCommandHandler {
   async handler(context: ChatCommandContext): Promise<string> {
     const givenUsername = context.args[0] ?? context.username
     const uuid = await getUuidIfExists(context.app.mojangApi, givenUsername)
-    if (uuid == undefined) {
-      return `${context.username}, Invalid username! (given: ${givenUsername})`
-    }
+    if (uuid == undefined) return usernameNotExists(givenUsername)
 
     const hypixelProfile = await context.app.hypixelApi.getPlayer(uuid)
     const skyblockProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
+    if (!skyblockProfile) return playerNeverPlayedSkyblock(givenUsername)
 
-    const catacombRuns = skyblockProfile.dungeons.dungeon_types.catacombs.tier_completions
-    const mastermodeRuns = skyblockProfile.dungeons.dungeon_types.master_catacombs.tier_completions
+    const dungeon = skyblockProfile.dungeons?.dungeon_types
+    if (!dungeon) return playerNeverPlayedDungeons(givenUsername)
+
+    const catacombRuns = dungeon.catacombs.tier_completions
+    const mastermodeRuns = dungeon.master_catacombs.tier_completions
 
     const totalRuns = this.getTotalRuns(catacombRuns) + this.getTotalRuns(mastermodeRuns)
 

--- a/src/instance/commands/triggers/slayer.ts
+++ b/src/instance/commands/triggers/slayer.ts
@@ -6,6 +6,7 @@ import {
   getSelectedSkyblockProfileRaw,
   getUuidIfExists,
   playerNeverPlayedSkyblock,
+  playerNeverPlayedSlayers,
   usernameNotExists
 } from '../common/util.js'
 
@@ -71,7 +72,8 @@ export default class Slayer extends ChatCommandHandler {
     const selectedProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
     if (!selectedProfile) return playerNeverPlayedSkyblock(givenUsername)
 
-    const slayerBosses = selectedProfile.slayer.slayer_bosses
+    const slayerBosses = selectedProfile.slayer?.slayer_bosses
+    if (!slayerBosses) return playerNeverPlayedSlayers(givenUsername)
 
     let chosenSlayer: string | undefined
     for (const [key, names] of Object.entries(Slayers)) {

--- a/src/instance/commands/triggers/slayer.ts
+++ b/src/instance/commands/triggers/slayer.ts
@@ -2,7 +2,12 @@ import type { Slayer as SlayerType } from 'hypixel-api-reborn'
 
 import type { ChatCommandContext } from '../common/command-interface.js'
 import { ChatCommandHandler } from '../common/command-interface.js'
-import { getSelectedSkyblockProfileRaw, getUuidIfExists } from '../common/util.js'
+import {
+  getSelectedSkyblockProfileRaw,
+  getUuidIfExists,
+  playerNeverPlayedSkyblock,
+  usernameNotExists
+} from '../common/util.js'
 
 const Slayers: Record<string, string[]> = {
   zombie: ['revenant', 'rev', 'zombie'],
@@ -61,12 +66,12 @@ export default class Slayer extends ChatCommandHandler {
     const givenSlayer = context.args[1] ?? 'overview'
 
     const uuid = await getUuidIfExists(context.app.mojangApi, givenUsername)
-    if (uuid == undefined) {
-      return `${context.username}, Invalid username! (given: ${givenUsername})`
-    }
+    if (uuid == undefined) return usernameNotExists(givenUsername)
 
-    const profile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
-    const slayerBosses = profile.slayer.slayer_bosses
+    const selectedProfile = await getSelectedSkyblockProfileRaw(context.app.hypixelApi, uuid)
+    if (!selectedProfile) return playerNeverPlayedSkyblock(givenUsername)
+
+    const slayerBosses = selectedProfile.slayer.slayer_bosses
 
     let chosenSlayer: string | undefined
     for (const [key, names] of Object.entries(Slayers)) {

--- a/src/instance/commands/triggers/soopy.ts
+++ b/src/instance/commands/triggers/soopy.ts
@@ -96,8 +96,14 @@ export default class Soopy extends ChatCommandHandler {
   }
 
   async handler(context: ChatCommandContext): Promise<string> {
-    const commandName = context.args[0]
+    const commandName: string | undefined = context.args[0]
     const commandArguments = context.args.length > 1 ? context.args.slice(1) : []
+
+    // It is possible to be undefined if no arg is supplied
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (commandName === undefined) {
+      return `${context.username}, Try ${this.getExample(context.commandPrefix)}`
+    }
 
     const fullCommand = `${commandName} ${commandArguments.join(' ')}`
 

--- a/src/types/hypixel-api-reborn.d.ts
+++ b/src/types/hypixel-api-reborn.d.ts
@@ -35,7 +35,7 @@ declare module 'hypixel-api-reborn' {
         infernal: number
       }
     }
-    slayer: SlayerProfile
+    slayer: SlayerProfile | undefined
     essence?: SkyblockV2Essence
   }
 

--- a/src/types/hypixel-api-reborn.d.ts
+++ b/src/types/hypixel-api-reborn.d.ts
@@ -11,7 +11,7 @@ declare module 'hypixel-api-reborn' {
   }
 
   export interface SkyblockV2ProfilesRaw {
-    profiles: SkyblockV2Profile[]
+    profiles: SkyblockV2Profile[] | undefined
   }
 
   export interface SkyblockV2Profile {
@@ -25,7 +25,7 @@ declare module 'hypixel-api-reborn' {
 
   export interface SkyblockV2Member {
     leveling?: { experience: number }
-    dungeons: SkyblockV2Dungeons
+    dungeons: SkyblockV2Dungeons | undefined
     nether_island_player_data: {
       kuudra_completed_tiers: {
         none: number


### PR DESCRIPTION
Many parts of the bridge just throw an error instead of handling exception. These errors usually go all the way up to the last error handler that controls whether the application exits with code 1. 

This patch aims to handle these exceptions and reserving the final error handler for fatal errors only.