### PR TITLE
fix(discord): commands send "event.instanceName" instead of the instance name

### DIFF
--- a/src/instance/discord/discord-instance.ts
+++ b/src/instance/discord/discord-instance.ts
@@ -288,7 +288,7 @@ export default class DiscordInstance extends ClientInstance<DiscordConfig> {
       color: Severity.GOOD,
       description: `${escapeDiscord(event.fullCommand)}\n**${escapeDiscord(event.commandResponse)}**`,
       footer: {
-        text: `event.instanceName${feedback ? ' (command feedback)' : ''}`
+        text: `${event.instanceName}${feedback ? ' (command feedback)' : ''}`
       }
     } satisfies APIEmbed
 


### PR DESCRIPTION
due to b3214a9a1b1a250c0a639c51785300ccf9862a22