### PR TITLE
feat(commands): add !parties

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A shorter version can also be used: `!- rtca`
 | !kuudra      | Get a player's kuudra completions `!kuudra hot`            | Anyone     |
 | !level       | Get a player's skyblock level                              | Anyone     |
 | !networth    | Calculate the in-game networth of a player                 | Anyone     |
+| !startparty  | Create public !parties to be viewed by guild members       | Anyone     |
 | !rps         | Play rock paper scissors `!rps rock`                       | Anyone     |
 | !roulette    | Has a chance of muting a player                            | Anyone     |
 | !runs        | Return a plauer's floor completions `!runs m7`             | Anyone     |

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "log4js": "^6.9.1",
         "minecraft-data": "^3.66.0",
         "minecraft-protocol": "^1.47.0",
+        "moment": "^2.30.1",
         "node-cache": "^5.1.2",
         "prismarine-chat": "^1.10.1",
         "prismarine-registry": "^1.7.0",
@@ -4395,6 +4396,15 @@
       "license": "MIT",
       "dependencies": {
         "nearley": "^2.19.5"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/moo": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "log4js": "^6.9.1",
     "minecraft-data": "^3.66.0",
     "minecraft-protocol": "^1.47.0",
+    "moment": "^2.30.1",
     "node-cache": "^5.1.2",
     "prismarine-chat": "^1.10.1",
     "prismarine-registry": "^1.7.0",

--- a/src/instance/commands/commands-instance.ts
+++ b/src/instance/commands/commands-instance.ts
@@ -18,6 +18,7 @@ import Kuudra from './triggers/kuudra.js'
 import Level from './triggers/level.js'
 import Networth from './triggers/networth.js'
 import Override from './triggers/override.js'
+import PartyManager from './triggers/party.js'
 import PersonalBest from './triggers/personal-best.js'
 import RockPaperScissors from './triggers/rock-paper-scissors.js'
 import Roulette from './triggers/roulette.js'
@@ -50,6 +51,7 @@ export class CommandsInstance extends ClientInstance<CommandsConfig> {
       new Level(),
       new Networth(),
       new Override(),
+      ...new PartyManager().resolveCommands(),
       new PersonalBest(),
       new RockPaperScissors(),
       new Roulette(),

--- a/src/instance/commands/triggers/party.ts
+++ b/src/instance/commands/triggers/party.ts
@@ -67,9 +67,10 @@ class PartyList extends ChatCommandHandler {
     for (const [index, party] of this.partyManager.activeParties.entries()) {
       // utc() is not directly exported
       // eslint-disable-next-line import/no-named-as-default-member
-      response += `${index + 1}. ${party.username} ${party.count} players ${party.purpose} with ${Moment.utc(party.expiresAt).fromNow(true)} left\n`
+      response += `${index + 1}. ${party.username}, ${party.count} players, ${party.purpose}, with ${Moment.utc(party.expiresAt).fromNow(true)} left\n`
     }
 
+    response += `/p join [name] or message the leader to join one of the parties`
     return response
   }
 }
@@ -141,7 +142,7 @@ class PartyStart extends ChatCommandHandler {
     } satisfies Party
 
     this.partyManager.activeParties.push(party)
-    return `${context.username}, party started!`
+    return `${context.username}, party started. Don't forget to open your party via /stream and tune in for any messages requesting to join! `
   }
 }
 

--- a/src/instance/commands/triggers/party.ts
+++ b/src/instance/commands/triggers/party.ts
@@ -76,7 +76,7 @@ class PartyList extends ChatCommandHandler {
 }
 
 class PartyStart extends ChatCommandHandler {
-  private static readonly MinPartySize = 1
+  private static readonly MinPartySize = 2
   private static readonly MaxPartySize = 100
   private static readonly MaxPurposeLength = 32
   private static readonly MaxDuration = 12 * 60 * 60 // 12 hours in seconds

--- a/src/instance/commands/triggers/party.ts
+++ b/src/instance/commands/triggers/party.ts
@@ -1,0 +1,176 @@
+// eslint-disable-next-line import/no-named-as-default
+import Moment from 'moment'
+
+import { ChannelType, InstanceType } from '../../../common/application-event.js'
+import { getDuration } from '../../../util/shared-util.js'
+import type { ChatCommandContext } from '../common/command-interface.js'
+import { ChatCommandHandler } from '../common/command-interface.js'
+
+interface Party {
+  username: string
+  count: number
+  purpose: string
+  expiresAt: number
+}
+
+export default class PartyManager {
+  public activeParties: Party[] = []
+  private readonly commands
+
+  constructor() {
+    this.commands = [new PartyList(this), new PartyStart(this), new PartyEnd(this)]
+  }
+
+  public resolveCommands(): ChatCommandHandler[] {
+    return this.commands
+  }
+
+  cleanExpiredParties(): void {
+    const currentTime = Date.now()
+    this.activeParties = this.activeParties.filter((party) => party.expiresAt > currentTime)
+  }
+
+  allowedExecution(context: ChatCommandContext): string | undefined {
+    if (context.channelType === ChannelType.OFFICER || context.channelType === ChannelType.PUBLIC) {
+      if (context.instanceType === InstanceType.MINECRAFT) return undefined
+      if (context.instanceType === InstanceType.DISCORD) return undefined
+    }
+
+    return 'Parties commands can only be executed in public and officer chat of either minecraft or discord.'
+  }
+}
+
+class PartyList extends ChatCommandHandler {
+  private readonly partyManager
+
+  constructor(partyManager: PartyManager) {
+    super({
+      name: 'Parties',
+      triggers: ['parties', 'party', 'listparty', 'listparties'],
+      description: 'List all active parties in guild',
+      example: `parties`
+    })
+
+    this.partyManager = partyManager
+  }
+
+  handler(context: ChatCommandContext): string {
+    const notAllowed = this.partyManager.allowedExecution(context)
+    if (notAllowed) return notAllowed
+
+    this.partyManager.cleanExpiredParties()
+    if (this.partyManager.activeParties.length === 0) {
+      return `${context.username}, There are no active parties. You can ${context.commandPrefix}startparty`
+    }
+
+    let response = `${context.username}, parties: `
+    for (const [index, party] of this.partyManager.activeParties.entries()) {
+      // utc() is not directly exported
+      // eslint-disable-next-line import/no-named-as-default-member
+      response += `${index + 1}. ${party.username} ${party.count} players ${party.purpose} with ${Moment.utc(party.expiresAt).fromNow(true)} left\n`
+    }
+
+    return response
+  }
+}
+
+class PartyStart extends ChatCommandHandler {
+  private static readonly MinPartySize = 1
+  private static readonly MaxPartySize = 100
+  private static readonly MaxPurposeLength = 32
+  private static readonly MaxDuration = 12 * 60 * 60 // 12 hours in seconds
+
+  private readonly partyManager
+
+  constructor(partyManager: PartyManager) {
+    super({
+      name: 'StartParty',
+      triggers: ['startparty'],
+      description: 'Create public !parties to be viewed by guild members with <count> <time> <purpose>',
+      example: `startparty 5 4h m7`
+    })
+
+    this.partyManager = partyManager
+  }
+
+  handler(context: ChatCommandContext): string {
+    const notAllowed = this.partyManager.allowedExecution(context)
+    if (notAllowed) return notAllowed
+
+    this.partyManager.cleanExpiredParties()
+    const alreadyExistingParty = this.partyManager.activeParties.some((party) => party.username === context.username)
+    if (alreadyExistingParty)
+      return `${context.username}, you already have an active party. ${context.commandPrefix}endparty first to start a new one.`
+
+    if (context.args.length < 3) return this.getExample(context.commandPrefix)
+    const countArgument = context.args[0]
+    const timeArgument = context.args[1]
+    const purpose = context.args
+      .slice(2)
+      .map((word) => word.trim())
+      .join(' ')
+      .trim()
+
+    const count = Number.parseInt(countArgument, 10)
+    if (
+      Number.isNaN(count) ||
+      !/^\d+$/.test(countArgument) ||
+      !(count >= PartyStart.MinPartySize && count <= PartyStart.MaxPartySize)
+    ) {
+      return `${context.username}, party count muse be between ${PartyStart.MinPartySize} and ${PartyStart.MaxPartySize}`
+    }
+    let durationInSeconds: number
+    try {
+      durationInSeconds = getDuration(timeArgument)
+    } catch {
+      return `${context.username}, party duration must be something like "4h" for 4 hours or "30m" for 30 minutes`
+    }
+    if (durationInSeconds > PartyStart.MaxDuration) {
+      return `${context.username}, party duration must be at most 12 hours. You can recreate the party any time if need more time!`
+    }
+
+    if (purpose.length > PartyStart.MaxPurposeLength) {
+      return `${context.username}, purpose must be at most ${PartyStart.MaxPurposeLength} character long`
+    }
+
+    const party = {
+      username: context.username,
+      count: count,
+      purpose: purpose,
+      expiresAt: Date.now() + durationInSeconds * 1000
+    } satisfies Party
+
+    this.partyManager.activeParties.push(party)
+    return `${context.username}, party started!`
+  }
+}
+
+class PartyEnd extends ChatCommandHandler {
+  private readonly partyManager
+
+  constructor(partyManager: PartyManager) {
+    super({
+      name: 'EndParty',
+      triggers: ['endparty'],
+      description: 'remove the party from the listing',
+      example: `endparty`
+    })
+
+    this.partyManager = partyManager
+  }
+
+  handler(context: ChatCommandContext): string {
+    const notAllowed = this.partyManager.allowedExecution(context)
+    if (notAllowed) return notAllowed
+
+    this.partyManager.cleanExpiredParties()
+    const changedParties = this.partyManager.activeParties.filter((party) => party.username !== context.username)
+    const removed = changedParties.length !== this.partyManager.activeParties.length
+    if (removed) {
+      this.partyManager.activeParties = changedParties
+      return `${context.username}, party ended.`
+    } else {
+      return `${context.username}, you don't have any active party to end. You can ${context.commandPrefix}startparty first`
+    }
+  }
+}


### PR DESCRIPTION
## Commands response
| Command                               | When                         | Response                                                                       |
---------------------------------------|------------------------------|--------------------------------------------------------------------------------|
 `!parties`                            | there are parties            | `aidn5, parties: 1. aidn5 5 players doing dungeons m7 with 12 hours left\n`    
 `!parties`                            | there are no parties         | `aidn5, There are no active parties. You can !startparty`                      
 `!endparty`                           | has party                    | `aidn5, party ended.`                                                          
 `!endparty`                           | has no party                 | `aidn5, you don't have any active party to end. You can !startparty first`     
 `!startparty 5 12h doing dungeons m7` | with success                 | `aidn5, party started!`                                                        
 `!startparty`                         | with an already active party | `aidn5, you already have an active party. !endparty first to start a new one.` 


## Configured limitations
- parties commands can only be used in public/officer chat of either minecraft or discord. private DM or in-game /msg will return an error message. To prevent people from outside the community from accessing them.
- party size must be between 1 (for anyone who wishes to broadcast their solo endeavor) and 100. 
- `purpose` can be multiple words. Up to 25 character max though.
- party can exist for up to 12 hours max. To avoid people spamming high numbers and then forgetting about it.


## Staff moderation
party management is processed using the username of the command executor. That means no obvious way for staff to override and moderate. This is the first command that saves user input. A new command will be added to replace the current `!override` to provide a way for staff to `sudo` execute commands as other users.
