### PR TITLE
Added handler for new security block message

### DIFF
--- a/src/instance/minecraft/handlers/state-handler.ts
+++ b/src/instance/minecraft/handlers/state-handler.ts
@@ -151,6 +151,17 @@ export default class StateHandler extends EventHandler<MinecraftInstance> {
         type: InstanceEventType.end,
         message: 'Account has been banned/blocked.\n' + "Won't try to re-login.\n"
       })
+    } else if (reason.includes('Your account is temporarily blocked')) {
+      this.clientInstance.logger.fatal('Instance will shut off since the account has been temporarily blocked')
+      this.clientInstance.status = Status.FAILED
+
+      this.clientInstance.app.emit('instance', {
+        localEvent: true,
+        instanceName: this.clientInstance.instanceName,
+        instanceType: InstanceType.MINECRAFT,
+        type: InstanceEventType.end,
+        message: "Account has been temporarily blocked.\nWon't try to re-login.\n\n" + reason.toString()
+      })
     } else {
       this.clientInstance.app.emit('instance', {
         localEvent: true,


### PR DESCRIPTION
Upon appealing a security blocked account, a 14 day timer is placed on the account until it unlocks. This scenario creates a unique 'ban screen' message, which should cause the instance to quit and not rejoin until reconnected manually. However, since the message was never scanned for, the default action was to automatically rejoin indefinitely.