### PR TITLE
feat(discord): increase inactivity time from 20s to 10m for options-handler

### DIFF
--- a/src/instance/discord/utility/options-handler.ts
+++ b/src/instance/discord/utility/options-handler.ts
@@ -148,6 +148,7 @@ interface OptionId {
 
 export class OptionsHandler {
   public static readonly BackButton = 'back-button'
+  private static readonly InactivityTime = 600_000
   private originalReply: InteractionResponse | undefined
   private enabled = true
   private path: string[] = []
@@ -178,7 +179,7 @@ export class OptionsHandler {
     })
     const timeoutId = setTimeout(() => {
       collector.stop()
-    }, 20_000)
+    }, OptionsHandler.InactivityTime)
 
     collector.on('collect', (messageInteraction) => {
       timeoutId.refresh()


### PR DESCRIPTION
The original inactivity time was too short not giving time to read anything before it disables itself.