### PR TITLE
feat: add !urchin command for player blacklist lookups

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -3,8 +3,10 @@ version: 2
 general:
   # Get Hypixel API key by creating one via dashboard.hypixel.net
   hypixelApiKey: '55adcfd6-abcd-477d-1234-12341234123a'
+
   # Optional: Urchin blacklist API key from https://urchin.ws
   # urchinApiKey: 'your-urchin-api-key'
+
   # Share basic anonymous metrics to display on the project main page as a way to show its popularity.
   # All metrics are anonymous and are limited to counting and never about anything specific
   shareMetrics: true

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -3,6 +3,8 @@ version: 2
 general:
   # Get Hypixel API key by creating one via dashboard.hypixel.net
   hypixelApiKey: '55adcfd6-abcd-477d-1234-12341234123a'
+  # Optional: Urchin blacklist API key from https://urchin.ws
+  # urchinApiKey: 'your-urchin-api-key'
   # Share basic anonymous metrics to display on the project main page as a way to show its popularity.
   # All metrics are anonymous and are limited to counting and never about anything specific
   shareMetrics: true

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -115,6 +115,7 @@ A shorter version can also be used: `!- rtca`
 | `uhc`            | Returns a player's UHC stats                                                       |
 | `unlink`         | Unlink Minecraft account from Discord                                              |
 | `unscramble`     | Start an unscrambling event                                                        |
+| `urchin`         | Returns a player's Urchin blacklist tags                                           |
 | `username`       | Show the Mojang UUID of a player                                                   |
 | `vengeance`      | Try your luck against another player for a 5 minute mute                           |
 | `warp`           | Warp a player out of a lobby                                                       |

--- a/src/application-config-ti.ts
+++ b/src/application-config-ti.ts
@@ -6,6 +6,7 @@ import * as t from "ts-interface-checker";
 
 export const GeneralConfig = t.iface([], {
   "hypixelApiKey": "string",
+  "urchinApiKey": t.opt("string"),
   "shareMetrics": "boolean",
 });
 

--- a/src/application-config.ts
+++ b/src/application-config.ts
@@ -2,6 +2,7 @@ export const ApplicationConfigVersion = 2
 
 export interface GeneralConfig {
   hypixelApiKey: string
+  urchinApiKey?: string
   shareMetrics: boolean
 }
 

--- a/src/application-config.ts
+++ b/src/application-config.ts
@@ -2,7 +2,7 @@ export const ApplicationConfigVersion = 2
 
 export interface GeneralConfig {
   hypixelApiKey: string
-  urchinApiKey?: string
+  urchinApiKey?: string //TODO: next config update, make this explicit. Use null if needed
   shareMetrics: boolean
 }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -20,6 +20,7 @@ import UnexpectedErrorHandler from './common/unexpected-error-handler.js'
 import { Core } from './core/core'
 import type { Hypixel } from './core/hypixel/hypixel'
 import { ApplicationLanguages, LanguageConfigurations } from './core/language-configurations'
+import type { Urchin } from './core/urchin/urchin'
 import type { MojangApi } from './core/users/mojang'
 import ApplicationIntegrity from './instance/application-integrity.js'
 import AutoRestart from './instance/auto-restart'
@@ -57,6 +58,7 @@ export default class Application extends Emittery<ApplicationEvents> implements 
 
   public readonly hypixelApi: Hypixel
   public readonly mojangApi: MojangApi
+  public readonly urchinApi: Urchin | undefined
 
   private readonly logger: Logger
   private readonly errorHandler: UnexpectedErrorHandler
@@ -101,9 +103,10 @@ export default class Application extends Emittery<ApplicationEvents> implements 
     this.applicationIntegrity.addConfigPath(this.backupDirectory)
     fs.mkdirSync(this.backupDirectory, { recursive: true })
 
-    this.core = new Core(this, config.general.hypixelApiKey)
+    this.core = new Core(this, config.general.hypixelApiKey, config.general.urchinApiKey)
     this.hypixelApi = this.core.hypixelApi
     this.mojangApi = this.core.mojangApi
+    this.urchinApi = this.core.urchinApi
 
     let selectedLanguage = this.core.languageConfigurations.getLanguage()
     if (!Object.values(ApplicationLanguages).includes(selectedLanguage)) {

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -44,6 +44,7 @@ import Punishments from './moderation/punishments'
 import PunishmentsEnforcer from './moderation/punishments-enforcer'
 import { PlaceholderManager } from './placeholder/placeholder-manager'
 import { SpontaneousEventsConfigurations } from './spontanmous-events-configurations'
+import { Urchin } from './urchin/urchin'
 import Autocomplete from './users/autocomplete'
 import { GuildManager } from './users/guild-manager'
 import { MojangApi } from './users/mojang'
@@ -87,6 +88,7 @@ export class Core extends Instance<InstanceType.Core> {
   public readonly commandsConfigurations: CommandsConfigurations
   public readonly spontaneousEventsConfigurations: SpontaneousEventsConfigurations
   public readonly hypixelApi: Hypixel
+  public readonly urchinApi: Urchin | undefined
   public readonly conditonsRegistry: ConditionsRegistry
   public readonly placeHolder: PlaceholderManager
 
@@ -94,7 +96,7 @@ export class Core extends Instance<InstanceType.Core> {
   private readonly sqliteManager: SqliteManager
   private readonly configurationsManager: ConfigurationsManager
 
-  public constructor(application: Application, hypixelApiKey: string) {
+  public constructor(application: Application, hypixelApiKey: string, urchinApiKey: string | undefined) {
     super(application, InternalInstancePrefix + 'core', InstanceType.Core)
 
     this.conditonsRegistry = new ConditionsRegistry()
@@ -130,6 +132,7 @@ export class Core extends Instance<InstanceType.Core> {
     this.moderationConfiguration = new ModerationConfigurations(this.configurationsManager)
     this.mojangApi = new MojangApi(this.sqliteManager)
     this.hypixelApi = new Hypixel(hypixelApiKey, this.sqliteManager, this.logger)
+    this.urchinApi = urchinApiKey === undefined ? undefined : new Urchin(urchinApiKey, this.logger)
 
     this.profanity = new Profanity(this.sqliteManager, this.moderationConfiguration)
     this.punishments = new Punishments(this.sqliteManager, application, this.logger)

--- a/src/core/urchin/urchin-api.d.ts
+++ b/src/core/urchin/urchin-api.d.ts
@@ -1,0 +1,15 @@
+// public api interfaces. Can't choose a naming convention
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface UrchinTag {
+  type: string
+  reason: string
+  added_by?: number
+  added_on: string
+  hide_username: boolean
+}
+
+export interface UrchinPlayerResponse {
+  uuid: string
+  tags: UrchinTag[]
+  rate_limit: number
+}

--- a/src/core/urchin/urchin.ts
+++ b/src/core/urchin/urchin.ts
@@ -1,0 +1,75 @@
+import { TTLCache } from '@isaacs/ttlcache'
+import DefaultAxios, { AxiosError, HttpStatusCode } from 'axios'
+import type { Logger } from 'log4js'
+import PromiseQueue from 'promise-queue'
+
+import Duration from '../../utility/duration'
+import RateLimiter from '../../utility/rate-limiter'
+
+import type { UrchinPlayerResponse } from './urchin-api'
+
+export class Urchin {
+  private static readonly ApiPath = 'https://urchin.ws'
+  private static readonly PlayerPath = '/player'
+
+  private static readonly RetryCount = 3
+  private static readonly DefaultSources = 'GAME,PARTY,PARTY_INVITES,CHAT,CHAT_MENTIONS,MANUAL,ME'
+
+  private readonly queue = new PromiseQueue(1)
+  private readonly rateLimit = new RateLimiter(1, 500)
+  private readonly cache = new TTLCache<string, UrchinPlayerResponse>({
+    max: 1000,
+    ttl: Duration.minutes(5).toMilliseconds()
+  })
+
+  constructor(
+    private readonly key: string,
+    private readonly logger: Logger
+  ) {}
+
+  async getPlayer(username: string, sources?: string): Promise<UrchinPlayerResponse | undefined> {
+    const cacheKey = username.toLowerCase()
+    const cached = this.cache.get(cacheKey)
+    if (cached !== undefined) return cached
+
+    const result = await this.queue.add(async () => {
+      let lastError: Error | undefined
+      for (let retry = 0; retry < Urchin.RetryCount; retry++) {
+        await this.rateLimit.wait()
+
+        try {
+          return await DefaultAxios.get<UrchinPlayerResponse>(
+            `${Urchin.ApiPath}${Urchin.PlayerPath}/${encodeURIComponent(username)}`,
+            {
+              params: {
+                key: this.key,
+                sources: sources ?? Urchin.DefaultSources
+              }
+            }
+          ).then((response) => response.data)
+        } catch (error: unknown) {
+          if (error instanceof Error) lastError = error
+
+          if (error instanceof AxiosError) {
+            if (error.status === HttpStatusCode.TooManyRequests) continue
+            if (error.status === HttpStatusCode.NotFound) return
+            if (error.status === HttpStatusCode.Unauthorized || error.status === HttpStatusCode.Forbidden) {
+              this.logger.error(`Urchin API key error: ${error.message}`)
+              return
+            }
+          }
+
+          throw error
+        }
+      }
+
+      throw lastError ?? new Error('Failed fetching Urchin data')
+    })
+
+    if (result !== undefined) {
+      this.cache.set(cacheKey, result)
+    }
+
+    return result
+  }
+}

--- a/src/instance/commands/commands-instance.ts
+++ b/src/instance/commands/commands-instance.ts
@@ -102,6 +102,7 @@ import TrophyFish from './triggers/trophy-fish'
 import Uhc from './triggers/uhc'
 import Unlink from './triggers/unlink.js'
 import Unscramble from './triggers/unscramble'
+import UrchinCommand from './triggers/urchin'
 import Uuid from './triggers/uuid'
 import Vengeance from './triggers/vengeance.js'
 import Warp from './triggers/warp.js'
@@ -211,6 +212,7 @@ export class CommandsInstance extends Instance<InstanceType.Commands> {
       new Uhc(),
       new Unlink(),
       new Unscramble(),
+      new UrchinCommand(),
       new Uuid(),
       new Vengeance(),
       new Warp(),

--- a/src/instance/commands/triggers/urchin.ts
+++ b/src/instance/commands/triggers/urchin.ts
@@ -1,0 +1,32 @@
+import type { ChatCommandContext } from '../../../common/commands.js'
+import { ChatCommandHandler } from '../../../common/commands.js'
+
+export default class UrchinCommand extends ChatCommandHandler {
+  constructor() {
+    super({
+      triggers: ['urchin'],
+      description: "Returns a player's Urchin blacklist tags",
+      example: `urchin %s`
+    })
+  }
+
+  async handler(context: ChatCommandContext): Promise<string> {
+    const givenUsername = context.args[0] ?? context.username
+
+    if (context.app.urchinApi === undefined) {
+      return `${givenUsername}, Urchin API is not configured.`
+    }
+
+    const response = await context.app.urchinApi.getPlayer(givenUsername)
+    if (response === undefined) {
+      return `${givenUsername}, player not found on Urchin.`
+    }
+
+    if (response.tags.length === 0) {
+      return `${givenUsername} has no Urchin tags.`
+    }
+
+    const formatted = response.tags.map((tag) => `${tag.type}: ${tag.reason}`).join(', ')
+    return `${givenUsername}'s Urchin tags: ${formatted}`
+  }
+}

--- a/src/instance/commands/triggers/urchin.ts
+++ b/src/instance/commands/triggers/urchin.ts
@@ -1,5 +1,6 @@
 import type { ChatCommandContext } from '../../../common/commands.js'
 import { ChatCommandHandler } from '../../../common/commands.js'
+import { usernameNotExists } from '../common/utility'
 
 export default class UrchinCommand extends ChatCommandHandler {
   constructor() {
@@ -11,22 +12,17 @@ export default class UrchinCommand extends ChatCommandHandler {
   }
 
   async handler(context: ChatCommandContext): Promise<string> {
-    const givenUsername = context.args[0] ?? context.username
+    if (context.app.urchinApi === undefined) return `${context.username}, Urchin API is not configured.`
 
-    if (context.app.urchinApi === undefined) {
-      return `${givenUsername}, Urchin API is not configured.`
-    }
+    const givenUsername = context.args.at(0) ?? context.username
+    const profile = await context.app.mojangApi.profileByUsername(givenUsername).catch(() => undefined)
+    if (profile === undefined) return usernameNotExists(context, givenUsername)
 
-    const response = await context.app.urchinApi.getPlayer(givenUsername)
-    if (response === undefined) {
-      return `${givenUsername}, player not found on Urchin.`
-    }
-
-    if (response.tags.length === 0) {
-      return `${givenUsername} has no Urchin tags.`
-    }
+    const response = await context.app.urchinApi.getPlayer(profile.name)
+    if (response === undefined) return `${profile.name}, player not found on Urchin.`
+    if (response.tags.length === 0) return `${profile.name} has no Urchin tags.`
 
     const lines = response.tags.map((tag) => `${tag.type}: ${tag.reason}`)
-    return `${givenUsername} has the following Urchin tags:\n${lines.join('\n')}`
+    return `${profile.name} has the following Urchin tags:\n${lines.join('\n')}`
   }
 }

--- a/src/instance/commands/triggers/urchin.ts
+++ b/src/instance/commands/triggers/urchin.ts
@@ -26,7 +26,7 @@ export default class UrchinCommand extends ChatCommandHandler {
       return `${givenUsername} has no Urchin tags.`
     }
 
-    const formatted = response.tags.map((tag) => `${tag.type}: ${tag.reason}`).join(', ')
-    return `${givenUsername}'s Urchin tags: ${formatted}`
+    const lines = response.tags.map((tag) => `${tag.type}: ${tag.reason}`)
+    return `${givenUsername} has the following Urchin tags:\n${lines.join('\n')}`
   }
 }


### PR DESCRIPTION
Adds support for the Urchin blacklist API. If you drop an optional urchinApiKey into general config, you get a new !urchin <username> chat command that pulls a player's tags from Urchin and prints them in chat. no req for the keys to be set its optional
the API client lives in src/core/urchin/ 