### PR TITLE
style(minecraft): replace EZPZ sanitization text

### DIFF
--- a/src/instance/minecraft/utility/ez-sanitizer.ts
+++ b/src/instance/minecraft/utility/ez-sanitizer.ts
@@ -2,7 +2,7 @@ export default class EzSanitizer {
   public process(message: string): string {
     const regex = /(?<!\w)ez(?!\w)/g
     message = message.replaceAll(regex, '_ez') // it is on purpose that this checks word boundary
-    message = message.replaceAll(/ezpz/gi, 'ezp_z') // and this one does NOT.
+    message = message.replaceAll(/ezpz/gi, 'EΖPΖ') // and this one does NOT.
     return message
   }
 }


### PR DESCRIPTION
This uses the character Ζ, not Z