### PR TITLE
fix(moderation): prevent double-wrapping hyperlinks when responsible and target users share the same username

### DIFF
--- a/src/instance/discord/discord-bridge.ts
+++ b/src/instance/discord/discord-bridge.ts
@@ -176,7 +176,7 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
       }
 
       const responsibleUser = 'responsible' in event ? event.responsible : undefined
-      if (responsibleUser !== undefined) {
+      if (responsibleUser !== undefined && responsibleUser.displayName() !== targetUser?.displayName()) {
         const username = responsibleUser.displayName()
         const clickableUsername = hyperlink(username, responsibleUser.profileLink())
         messageBody = messageBody.replaceAll(escapeMarkdown(username), clickableUsername)


### PR DESCRIPTION
Before:
<img width="537" height="142" alt="image" src="https://github.com/user-attachments/assets/dfa1d7c7-ea5c-4bc7-8a37-b85379cd4424" />