### PR TITLE
feat(discord): Add support for changing message format

### DIFF
--- a/src/core/discord/discord-configurations.ts
+++ b/src/core/discord/discord-configurations.ts
@@ -23,6 +23,14 @@ export class DiscordConfigurations {
   public setOfficerChannelIds(channelIds: string[]): void {
     this.configuration.setStringArray('officerChannelIds', channelIds)
   }
+  
+  public getMessageFormat(): string { 
+    return this.configuration.getString('messageFormat', 'Webhook')
+  }
+
+  public setMessageFormat(newMessageFormat: string): void {
+    this.configuration.setString('messageFormat', newMessageFormat)
+  }
 
   public getHelperRoleIds(): string[] {
     return this.configuration.getStringArray('helperRoleIds', [])

--- a/src/core/discord/discord-configurations.ts
+++ b/src/core/discord/discord-configurations.ts
@@ -1,6 +1,12 @@
 import Duration from '../../utility/duration'
 import type { Configuration, ConfigurationsManager } from '../configurations'
 
+export enum DiscordChatFormat {
+  MinecraftRender = 'minecraftRender',
+  Webhook = 'webhook',
+  Embed = 'embed'
+}
+
 export class DiscordConfigurations {
   private readonly configuration: Configuration
 
@@ -22,14 +28,6 @@ export class DiscordConfigurations {
 
   public setOfficerChannelIds(channelIds: string[]): void {
     this.configuration.setStringArray('officerChannelIds', channelIds)
-  }
-  
-  public getMessageFormat(): string { 
-    return this.configuration.getString('messageFormat', 'Webhook')
-  }
-
-  public setMessageFormat(newMessageFormat: string): void {
-    this.configuration.setString('messageFormat', newMessageFormat)
   }
 
   public getHelperRoleIds(): string[] {
@@ -72,12 +70,12 @@ export class DiscordConfigurations {
     this.configuration.setBoolean('enforceVerification', enabled)
   }
 
-  public getTextToImage(): boolean {
-    return this.configuration.getBoolean('textToImage', false)
+  public getChatFormat(): DiscordChatFormat {
+    return this.configuration.getString('chatFormat', DiscordChatFormat.Webhook) as DiscordChatFormat
   }
 
-  public setTextToImage(enabled: boolean): void {
-    this.configuration.setBoolean('textToImage', enabled)
+  public setChatFormat(format: DiscordChatFormat): void {
+    this.configuration.setString('chatFormat', format)
   }
 
   public getGuildOnline(): boolean {

--- a/src/core/initialize-database.ts
+++ b/src/core/initialize-database.ts
@@ -9,7 +9,7 @@ import type { Logger, Logger as Logger4Js } from 'log4js'
 import type Application from '../application'
 import type { SqliteManager } from '../common/sqlite-manager'
 
-const CurrentVersion = 14
+const CurrentVersion = 15
 
 export function initializeCoreDatabase(application: Application, sqliteManager: SqliteManager, name: string): void {
   sqliteManager.setTargetVersion(CurrentVersion)
@@ -55,6 +55,9 @@ export function initializeCoreDatabase(application: Application, sqliteManager: 
   })
   sqliteManager.registerMigrator(13, (database, logger, postCleanupActions, newlyCreated) => {
     migrateFrom13to14(database, logger, newlyCreated)
+  })
+  sqliteManager.registerMigrator(14, (database, logger, postCleanupActions, newlyCreated) => {
+    migrateFrom14to15(database, logger, newlyCreated)
   })
 
   sqliteManager.migrate(name)
@@ -724,6 +727,26 @@ function migrateFrom13to14(database: Database, logger: Logger4Js, newlyCreated: 
   database.exec('ALTER TABLE "punishments" ADD COLUMN "expired" INTEGER NOT NULL DEFAULT 0;')
 
   database.pragma('user_version = 14')
+}
+
+function migrateFrom14to15(database: Database, logger: Logger4Js, newlyCreated: boolean): void {
+  if (!newlyCreated) logger.debug('Migrating database from version 14 to 15')
+
+  const selectedOption = database
+    .prepare('SELECT value FROM "configurations" WHERE category = ? AND name = ?')
+    .pluck(true)
+    .get('discord', 'textToImage') as string | undefined
+  if (selectedOption !== undefined) {
+    const result = database
+      .prepare('INSERT INTO "configurations" (category, name, value) VALUES (?, ?, ?)')
+      .run('discord', 'chatFormat', selectedOption === '1' ? 'minecraftRender' : 'webhook')
+
+    assert.strictEqual(result.changes, 1)
+  }
+
+  database.exec("DELETE FROM 'configurations' WHERE category = 'discord' AND name = 'textToImage'")
+
+  database.pragma('user_version = 15')
 }
 
 function findIdentifier(identifiers: string[]): { originInstance: string; userId: string } | undefined {

--- a/src/instance/discord/commands/settings.ts
+++ b/src/instance/discord/commands/settings.ts
@@ -591,6 +591,29 @@ function fetchDiscordOptions(application: Application): CategoryOption {
         }
       },
       {
+        type: OptionType.PresetList,
+
+        name: `Message Format`,
+        description: 'Allows to change how Minecraft messages are displayed in the Discord',
+
+        min: 1,
+        max: 1,
+
+        getOption: () => [discord.getMessageFormat()],
+        setOption: (values) => {
+          let selected = values[0]
+          if (!['Webhook', 'Embed'].includes(selected))
+            selected = 'Webhook'
+          assert.notStrictEqual(selected, undefined)
+          assert.ok(['Webhook', 'Embed'].includes(selected))
+          discord.setMessageFormat(selected)
+        },
+        options: [
+          {label: 'Webhook', value: 'Webhook', description: 'Send messages using webhooks, stylizing Minecraft messages like actual users'},
+          {label: 'Embed', value: 'Embed', description: 'Send messages using embeds, the same way instance statuses are sent'}
+        ]
+      },
+      {
         type: OptionType.Boolean,
         name: 'Always Reply',
         description:

--- a/src/instance/discord/commands/settings.ts
+++ b/src/instance/discord/commands/settings.ts
@@ -24,6 +24,7 @@ import type Application from '../../../application.js'
 import { Color, InstanceType, Permission } from '../../../common/application-event.js'
 import type { DiscordCommandHandler } from '../../../common/commands.js'
 import type UnexpectedErrorHandler from '../../../common/unexpected-error-handler.js'
+import { DiscordChatFormat } from '../../../core/discord/discord-configurations'
 import { translateInstanceMessage, translateInstanceStatus } from '../../../core/instance/instance-language'
 import { ApplicationLanguages } from '../../../core/language-configurations'
 import type { ProxyConfig } from '../../../core/minecraft/sessions-manager'
@@ -594,23 +595,34 @@ function fetchDiscordOptions(application: Application): CategoryOption {
         type: OptionType.PresetList,
 
         name: `Message Format`,
-        description: 'Allows to change how Minecraft messages are displayed in the Discord',
+        description: 'Change how messages are displayed in Discord',
 
         min: 1,
         max: 1,
 
-        getOption: () => [discord.getMessageFormat()],
+        getOption: () => [discord.getChatFormat()],
         setOption: (values) => {
-          let selected = values[0]
-          if (!['Webhook', 'Embed'].includes(selected))
-            selected = 'Webhook'
-          assert.notStrictEqual(selected, undefined)
-          assert.ok(['Webhook', 'Embed'].includes(selected))
-          discord.setMessageFormat(selected)
+          const selected = values[0] as DiscordChatFormat
+          assert.ok(Object.values(DiscordChatFormat).includes(selected))
+          discord.setChatFormat(selected)
         },
         options: [
-          {label: 'Webhook', value: 'Webhook', description: 'Send messages using webhooks, stylizing Minecraft messages like actual users'},
-          {label: 'Embed', value: 'Embed', description: 'Send messages using embeds, the same way instance statuses are sent'}
+          {
+            label: 'Webhook',
+            value: DiscordChatFormat.Webhook,
+            description: 'Send messages using webhooks, stylizing Minecraft messages like actual users'
+          },
+          {
+            label: 'Minecraft Rendering',
+            value: DiscordChatFormat.MinecraftRender,
+            description:
+              'Render chat messages the same way Minecraft renders them in-game. **DOES NOT WORK ON WINDOWS OS.**'
+          },
+          {
+            label: 'Embed',
+            value: DiscordChatFormat.Embed,
+            description: 'Send messages using embeds, the same way instance statuses are sent'
+          }
         ]
       },
       {
@@ -630,16 +642,6 @@ function fetchDiscordOptions(application: Application): CategoryOption {
         getOption: () => discord.getEnforceVerification(),
         toggleOption: () => {
           discord.setEnforceVerification(!discord.getEnforceVerification())
-        }
-      },
-      {
-        type: OptionType.Boolean,
-        name: 'Minecraft Text Images',
-        description:
-          'Render chat messages the same way they are rendered in Minecraft in-game. **DOES NOT WORK ON WINDOWS OS.**',
-        getOption: () => discord.getTextToImage(),
-        toggleOption: () => {
-          discord.setTextToImage(!discord.getTextToImage())
         }
       },
       {

--- a/src/instance/discord/discord-bridge.ts
+++ b/src/instance/discord/discord-bridge.ts
@@ -143,7 +143,7 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
   private async sendAsEmbed(event: ChatEvent, channelId: string, username: string): Promise<void> {
     if (event.instanceType !== InstanceType.Minecraft)
       return
-    let displayUsername = username
+    const displayUsername = username
 
     const embedFooters: string[] = []
     switch (event.channelType) {
@@ -166,23 +166,26 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
       embedFooters.push(event.instanceName)
     }
 
-    const channel: SendableChannels = await this.clientInstance.getClient().channels.fetch(channelId)
+    const channel = await this.clientInstance.getClient().channels.fetch(channelId)
+    assert.ok(channel != undefined)
+    assert.ok(channel.isSendable())
     const message = await channel.send({
       embeds: [
         {
           description: escapeMarkdown(event.message),
           color: this.getRandomColor(),
-          timestamp: new Date(),
+          timestamp: new Date().toISOString(),
           footer: embedFooters.length > 0 ? { text: embedFooters.join(' • ') } : undefined,
           author: {
             name: displayUsername,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             icon_url: event.user.avatar()
           }
         }
       ]
     })
     this.messageAssociation.addMessageId(event.eventId, {
-      guildId: message.guildId,
+      guildId: message.guildId ?? undefined,
       channelId: message.channelId,
       messageId: message.id
     })
@@ -195,7 +198,7 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
    */
   private getRandomColor(): number {
     const min = Math.ceil(0)
-    const max = Math.floor(16777215)
+    const max = Math.floor(16_777_215)
     return Math.floor(Math.random() * (max - min + 1)) + min
   }
 

--- a/src/instance/discord/discord-bridge.ts
+++ b/src/instance/discord/discord-bridge.ts
@@ -141,8 +141,6 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
   }
 
   private async sendAsEmbed(event: ChatEvent, channelId: string, username: string): Promise<void> {
-    if (event.instanceType !== InstanceType.Minecraft)
-      return
     const displayUsername = username
 
     const embedFooters: string[] = []

--- a/src/instance/discord/discord-bridge.ts
+++ b/src/instance/discord/discord-bridge.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 
-import type { APIEmbed, ApplicationEmoji, Message, TextBasedChannelFields, Webhook } from 'discord.js'
+import type { APIEmbed, ApplicationEmoji, Message, TextBasedChannelFields, Webhook, SendableChannels } from 'discord.js'
 import { AttachmentBuilder, ChannelType as DiscordChannelType, escapeMarkdown, hyperlink } from 'discord.js'
 import type { Logger } from 'log4js'
 
@@ -98,6 +98,7 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
   }
 
   async onChat(event: ChatEvent): Promise<void> {
+    const config = this.application.core.discordConfigurations
     const channels = this.resolveChannels([event.channelType])
     const username = event.user.displayName()
 
@@ -112,31 +113,98 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
         const formattedMessage = this.removeGuildPrefix(event.rawMessage)
         const image = MinecraftRenderer.generateMessageImage(formattedMessage)
         await this.sendImageToChannels(event.eventId, [channelId], [image])
-      } else {
-        const webhook = await this.getWebhook(channelId)
+        return // slight "guard clause" thing here to prevent a big else block
+      }
 
-        let displayUsername =
-          event.instanceType === InstanceType.Discord && event.replyUsername !== undefined
-            ? `${username}⇾${event.replyUsername}`
-            : username
-
-        if (this.application.core.applicationConfigurations.getOriginTag()) {
-          displayUsername += event.instanceType === InstanceType.Discord ? ` [DC]` : ` [${event.instanceName}]`
-        }
-
-        const message = await webhook.send({
-          content: escapeMarkdown(event.message),
-          username: displayUsername,
-          avatarURL: event.user.avatar(),
-          allowedMentions: { parse: [] }
-        })
-        this.messageAssociation.addMessageId(event.eventId, {
-          guildId: message.guildId,
-          channelId: message.channelId,
-          messageId: message.id
-        })
+      switch (config.getMessageFormat()) {
+        case 'Webhook':
+          await this.sendAsWebhook(event, channelId, username)
+          break
+        case 'Embed':
+          await this.sendAsEmbed(event, channelId, username)
+          break
       }
     }
+  }
+
+  private async sendAsEmbed(event: ChatEvent, channelId: string, username: string): Promise<void> {
+    if (event.instanceType !== InstanceType.Minecraft)
+      return
+    let displayUsername = username
+
+    let embedFooter = ""
+    switch (event.channelType) {
+      case ChannelType.Private:
+        embedFooter = "<3" // TODO genuinely no clue how to behave thenn
+        break
+      case ChannelType.Public:
+      case ChannelType.Officer:
+        embedFooter = event.guildRank
+        break
+    }
+
+    if (this.application.core.applicationConfigurations.getOriginTag()) {
+      embedFooter += ` • ${event.instanceName}`
+    }
+
+    const channel: SendableChannels = await this.clientInstance.getClient().channels.fetch(channelId)
+    const message = await channel.send({
+      embeds: [
+        {
+          description: escapeMarkdown(event.message),
+          color: this.getRandomColor(),
+          timestamp: new Date(),
+          footer: {
+            text: embedFooter
+          },
+          author: {
+            name: displayUsername,
+            icon_url: event.user.avatar()
+          }
+        }
+      ]
+    })
+    this.messageAssociation.addMessageId(event.eventId, {
+      guildId: message.guildId,
+      channelId: message.channelId,
+      messageId: message.id
+    })
+  }
+
+  /**
+   * This is a placeholder method to randomly assign a color to embeds.
+   * Any change suggestions are welcome.
+   * @returns a randomly-chosen color in decimal format
+   */
+  private getRandomColor(): number {
+    const min = Math.ceil(0)
+    const max = Math.floor(16777215)
+    return Math.floor(Math.random() * (max - min + 1)) + min
+  }
+
+  private async sendAsWebhook(event: ChatEvent, channelId: string, username: string): Promise<void> {
+    const webhook = await this.getWebhook(channelId)
+
+    let displayUsername =
+      event.instanceType === InstanceType.Discord && event.replyUsername !== undefined
+        ? `${username}⇾${event.replyUsername}`
+        : username
+
+    if (this.application.core.applicationConfigurations.getOriginTag()) {
+      displayUsername += event.instanceType === InstanceType.Discord ? ` [DC]` : ` [${event.instanceName}]`
+    }
+
+    const message = await webhook.send({
+      content: escapeMarkdown(event.message),
+      username: displayUsername,
+      avatarURL: event.user.avatar(),
+      allowedMentions: { parse: [] }
+    })
+    this.messageAssociation.addMessageId(event.eventId, {
+      guildId: message.guildId,
+      channelId: message.channelId,
+      messageId: message.id
+    })
   }
 
   async onGuildPlayer(event: GuildPlayerEvent): Promise<void> {

--- a/src/instance/discord/discord-bridge.ts
+++ b/src/instance/discord/discord-bridge.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 
-import type { APIEmbed, ApplicationEmoji, Message, TextBasedChannelFields, Webhook, SendableChannels } from 'discord.js'
+import type { APIEmbed, ApplicationEmoji, Message, TextBasedChannelFields, Webhook } from 'discord.js'
 import { AttachmentBuilder, ChannelType as DiscordChannelType, escapeMarkdown, hyperlink } from 'discord.js'
 import type { Logger } from 'log4js'
 
@@ -34,6 +34,7 @@ import {
 import Bridge from '../../common/bridge.js'
 import type UnexpectedErrorHandler from '../../common/unexpected-error-handler.js'
 import type { User } from '../../common/user'
+import { DiscordChatFormat } from '../../core/discord/discord-configurations'
 import MinecraftRenderer from '../../utility/minecraft-renderer'
 import { beautifyInstanceName } from '../../utility/shared-utility'
 
@@ -105,24 +106,36 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
     for (const channelId of channels) {
       if (event.instanceType === InstanceType.Discord && channelId === event.channelId) continue
 
-      if (
-        event.instanceType === InstanceType.Minecraft &&
-        this.minecraftRenderImageEnabled() &&
-        MinecraftRenderer.renderSupported()
-      ) {
-        const formattedMessage = this.removeGuildPrefix(event.rawMessage)
-        const image = MinecraftRenderer.generateMessageImage(formattedMessage)
-        await this.sendImageToChannels(event.eventId, [channelId], [image])
-        return // slight "guard clause" thing here to prevent a big else block
-      }
-
-      switch (config.getMessageFormat()) {
-        case 'Webhook':
+      const chatFormat = config.getChatFormat()
+      switch (chatFormat) {
+        case DiscordChatFormat.MinecraftRender: {
+          if (
+            event.instanceType === InstanceType.Minecraft &&
+            this.minecraftRenderImageEnabled() &&
+            MinecraftRenderer.renderSupported()
+          ) {
+            const formattedMessage = this.removeGuildPrefix(event.rawMessage)
+            const image = MinecraftRenderer.generateMessageImage(formattedMessage)
+            await this.sendImageToChannels(event.eventId, [channelId], [image])
+          } else {
+            // default fallback
+            await this.sendAsWebhook(event, channelId, username)
+          }
+          break
+        }
+        case DiscordChatFormat.Webhook: {
           await this.sendAsWebhook(event, channelId, username)
           break
-        case 'Embed':
+        }
+        case DiscordChatFormat.Embed: {
           await this.sendAsEmbed(event, channelId, username)
           break
+        }
+        default: {
+          chatFormat satisfies never
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          assert.fail(`unknown chat format: ${chatFormat}`)
+        }
       }
     }
   }
@@ -132,19 +145,25 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
       return
     let displayUsername = username
 
-    let embedFooter = ""
+    const embedFooters: string[] = []
     switch (event.channelType) {
-      case ChannelType.Private:
-        embedFooter = "<3" // TODO genuinely no clue how to behave thenn
+      case ChannelType.Private: {
+        // do nothing
         break
+      }
       case ChannelType.Public:
-      case ChannelType.Officer:
-        embedFooter = event.guildRank
+      case ChannelType.Officer: {
+        if (event.instanceType === InstanceType.Minecraft) embedFooters.push(event.guildRank)
         break
+      }
+      default: {
+        event satisfies never
+        assert.fail(`Unknown chat channelType from ${JSON.stringify(event)}`)
+      }
     }
 
     if (this.application.core.applicationConfigurations.getOriginTag()) {
-      embedFooter += ` • ${event.instanceName}`
+      embedFooters.push(event.instanceName)
     }
 
     const channel: SendableChannels = await this.clientInstance.getClient().channels.fetch(channelId)
@@ -154,9 +173,7 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
           description: escapeMarkdown(event.message),
           color: this.getRandomColor(),
           timestamp: new Date(),
-          footer: {
-            text: embedFooter
-          },
+          footer: embedFooters.length > 0 ? { text: embedFooters.join(' • ') } : undefined,
           author: {
             name: displayUsername,
             icon_url: event.user.avatar()
@@ -724,7 +741,7 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
 
   private minecraftRenderImageEnabled(): boolean {
     const config = this.application.core.discordConfigurations
-    return config.getTextToImage()
+    return config.getChatFormat() === DiscordChatFormat.MinecraftRender
   }
 }
 


### PR DESCRIPTION
Some of my guildmates were complaining about the way this bridge bot displays messages from the game, as in, they complained about it using Discord's Webhooks, rather than the embed format they were used to.
I decided to bring it over and make it a potential customizability trait, so that bridge hosts can decide between one format or the other.

My only shortcomings:
* the TODO comment (the heart)
* the `getRandomColor()` method

I have this running on my bridge bot as of right now with no issues in sight, all things are operational.