### PR TITLE
feat: add start.bat for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,23 @@ git clone https://github.com/aidn3/hypixel-guild-discord-bridge
 
 ### Install And Run
 
-If you are on linux, execute this command to auto download all libraries and start the application.
-It will also keep the application up to date:
+Execute the command specific to your operating system to auto download all libraries and start the application.
+It will also keep the application up to date.
+
+If you are running the application on Linux operating system:
 
 ```shell
 ./start.sh
 ```
 
 If you are running the application on Windows operating system:
+
+```shell
+"./start.bat"
+```
+
+Alternatively, you can run these commands if the above options are not viable or if you prefer not to use them.
+This method does **not** keep the application up to date:
 
 ```shell
 npm install

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,21 @@
+@echo off
+:loop
+REM Delete any temporarily changes such as from package-lock.json
+REM This will not delete logs or configurations
+REM But might delete any custom plugins if they are not in in logs or config dir
+git reset --hard
+REM Auto update the application after every restart
+git pull
+
+REM Install all dependencies after any potential application update
+call npm install
+REM Update packages that need to be always up to date
+call npm update skyhelper-networth
+
+REM Start the application
+REM An alternative way is to "npm start" the application
+node --import tsx/esm index.ts
+
+echo Server crashed. Respawning.. 1>&2
+timeout /t 10 /nobreak >nul
+goto loop


### PR DESCRIPTION
`start.bat` works functionally the same as `start.sh`. This allows Windows users to start the application with the same additional functionality.