### PR TITLE
feat(moderation): add "cp" to default profanity terms

### DIFF
--- a/src/core/moderation/moderation-configurations.ts
+++ b/src/core/moderation/moderation-configurations.ts
@@ -63,7 +63,8 @@ export class ModerationConfigurations {
       'god',
       'shit',
       'balls',
-      'retard'
+      'retard',
+      'cp'
     ])
   }
 


### PR DESCRIPTION
Added the abbreviation “cp” as an included term in the profanity filter because Discord often interprets it as “child pornography” rather than “chestplate”, which may result in Discord account suspension if misused.