### PR TITLE
feat(discord): properly resolve reply username

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -31,6 +31,7 @@ import { DiscordConfigurations } from './discord/discord-configurations'
 import { DiscordEmojis } from './discord/discord-emojis'
 import { DiscordLeaderboards } from './discord/discord-leaderboards'
 import { DiscordTemporarilyInteractions } from './discord/discord-temporarily-interactions'
+import { DiscordUserMessage } from './discord/discord-user-message'
 import { DiscordLinkButton } from './discord/link-button'
 import { UserConditions } from './discord/user-conditions'
 import { Hypixel } from './hypixel/hypixel'
@@ -73,6 +74,7 @@ export class Core extends Instance {
   public readonly discordLeaderboards: DiscordLeaderboards
   public readonly discordTemporarilyInteractions: DiscordTemporarilyInteractions
   public readonly discordLinkButton: DiscordLinkButton
+  public readonly discordUserMessage: DiscordUserMessage
   public readonly discordEmojis: DiscordEmojis
   public readonly discordUserConditions: UserConditions
 
@@ -132,6 +134,7 @@ export class Core extends Instance {
       this.discordConfigurations
     )
     this.discordLinkButton = new DiscordLinkButton(this.sqliteManager)
+    this.discordUserMessage = new DiscordUserMessage(this.sqliteManager, this.users)
     this.discordEmojis = new DiscordEmojis(this.sqliteManager)
     this.discordUserConditions = new UserConditions(this.sqliteManager)
 
@@ -303,6 +306,7 @@ export class Core extends Instance {
       this.discordLeaderboards.remove(messagesIds)
       this.discordTemporarilyInteractions.remove(messagesIds)
       this.discordLinkButton.remove(messagesIds)
+      this.discordUserMessage.remove(messagesIds)
     })
 
     transaction()

--- a/src/core/discord/discord-user-message.ts
+++ b/src/core/discord/discord-user-message.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert'
+
+import type { UserId } from '../../common/application-event'
+import type { SqliteManager } from '../../common/sqlite-manager'
+import type { AnonymousUser, UserIdentifier } from '../../common/user'
+import type { Users } from '../users'
+
+export class DiscordUserMessage {
+  constructor(
+    private readonly sqliteManager: SqliteManager,
+    private readonly users: Users
+  ) {}
+
+  public add(messageId: string, user: AnonymousUser): void {
+    const database = this.sqliteManager.getDatabase()
+    const transaction = database.transaction(() => {
+      const userId = this.users.resolveUserId(user.getUserIdentifier())
+      const insert = database.prepare<[typeof messageId, UserId]>(
+        'INSERT INTO "discordMessageSender" (messageId, userId) VALUES (?, ?)'
+      )
+
+      const result = insert.run(messageId, userId)
+      assert.strictEqual(result.changes, 1)
+    })
+
+    transaction()
+  }
+
+  public getUserIdentifier(messageId: string): UserIdentifier | undefined {
+    const database = this.sqliteManager.getDatabase()
+
+    const transaction = database.transaction(() => {
+      const userId = database
+        .prepare<[string], UserId>('SELECT userId FROM "discordMessageSender" WHERE messageId = ?')
+        .pluck(true)
+        .get(messageId)
+
+      if (userId === undefined) return
+
+      const identifier = this.users.getUserIdentifier(userId)
+      assert.ok(identifier !== undefined)
+      return identifier
+    })
+
+    return transaction()
+  }
+
+  public remove(messagesIds: string[]): number {
+    const database = this.sqliteManager.getDatabase()
+    const transaction = database.transaction(() => {
+      const update = database.prepare('DELETE FROM "discordMessageSender" WHERE messageId = ?')
+
+      let count = 0
+      for (const entry of messagesIds) {
+        count += update.run(entry).changes
+      }
+
+      return count
+    })
+
+    return transaction()
+  }
+}

--- a/src/core/initialize-database.ts
+++ b/src/core/initialize-database.ts
@@ -79,6 +79,9 @@ export function initializeCoreDatabase(application: Application, sqliteManager: 
   sqliteManager.registerMigrator((database) => {
     migrateFrom22to23(database)
   })
+  sqliteManager.registerMigrator((database) => {
+    migrateFrom23to24(database)
+  })
 
   sqliteManager.migrate(name)
 }
@@ -837,6 +840,15 @@ function migrateFrom21to22(database: Database): void {
 
 function migrateFrom22to23(database: Database): void {
   database.exec("UPDATE configurations SET category = 'admin' WHERE category = 'general' AND name = 'autoRestart';")
+}
+
+function migrateFrom23to24(database: Database): void {
+  database.exec(
+    'CREATE TABLE "discordMessageSender" (' +
+      '  messageId TEXT PRIMARY KEY NOT NULL,' +
+      '  userId INTEGER NOT NULL REFERENCES users(id)' +
+      ' ) STRICT'
+  )
 }
 
 function findIdentifier(identifiers: string[]): { originInstance: string; userId: string } | undefined {

--- a/src/instance/discord/chat-manager.ts
+++ b/src/instance/discord/chat-manager.ts
@@ -61,6 +61,7 @@ export default class ChatManager extends SubInstance<DiscordInstance, Client> {
 
     const userProfile = this.clientInstance.profileByUser(event.author, event.member ?? undefined)
     const user = await this.application.core.initializeDiscordUser(userProfile)
+    this.application.core.discordUserMessage.add(event.id, user)
 
     if (!user.verified() && config.getEnforceVerification()) {
       const emoji = event.client.application.emojis.cache.find((emoji) => emoji.name === UnverifiedReaction.name)
@@ -171,6 +172,12 @@ export default class ChatManager extends SubInstance<DiscordInstance, Client> {
 
   private async getReplyUsername(messageEvent: Message): Promise<string | undefined> {
     if (messageEvent.reference?.messageId === undefined) return
+
+    const identifier = this.application.core.discordUserMessage.getUserIdentifier(messageEvent.reference.messageId)
+    if (identifier !== undefined) {
+      const user = await this.application.core.initializeUser(identifier, { guild: messageEvent.guild ?? undefined })
+      return user.displayName()
+    }
 
     const channel = messageEvent.channel
 

--- a/src/instance/discord/discord-bridge.ts
+++ b/src/instance/discord/discord-bridge.ts
@@ -114,7 +114,10 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
           ) {
             const formattedMessage = this.removeGuildPrefix(event.rawMessage)
             const image = MinecraftRenderer.generateMessageImage(formattedMessage)
-            await this.sendImageToChannels(event.eventId, [channelId], [image])
+            const messages = await this.sendImageToChannels(event.eventId, [channelId], [image])
+            for (const message of messages) {
+              this.application.core.discordUserMessage.add(message.id, event.user)
+            }
           } else {
             // default fallback
             await this.sendAsWebhook(event, channelId, username)
@@ -185,6 +188,7 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
       channelId: message.channelId,
       messageId: message.id
     })
+    this.application.core.discordUserMessage.add(message.id, event.user)
   }
 
   /**
@@ -222,6 +226,7 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
       channelId: message.channelId,
       messageId: message.id
     })
+    this.application.core.discordUserMessage.add(message.id, event.user)
   }
 
   async onGuildPlayer(event: GuildPlayerEvent): Promise<void> {
@@ -306,6 +311,12 @@ export default class DiscordBridge extends Bridge<DiscordInstance> {
         createdAt: currentTime
       }))
       await this.messageDeleter.add(entries)
+    }
+
+    if (event.user !== undefined) {
+      for (const message of messages) {
+        this.application.core.discordUserMessage.add(message.id, event.user)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes not being able to resolve the up-to-date user's username OR failing to resolve anything if the sending format is incompatible with detecting username from within the sent-message itself.