### PR TITLE
fix(commands): add fallback for processTimeModifier in !forge

### DIFF
--- a/src/core/hypixel/hypixel-skyblock.ts
+++ b/src/core/hypixel/hypixel-skyblock.ts
@@ -309,7 +309,7 @@ export interface SkyblockForge {
 export interface SkyblockForgeEntry {
   id: string
   startTime: number
-  processTimeModifier: number
+  processTimeModifier?: number
 }
 
 export interface MayorResponse extends HypixelSuccessResponse {

--- a/src/instance/commands/triggers/forge.ts
+++ b/src/instance/commands/triggers/forge.ts
@@ -84,7 +84,7 @@ export default class Forge extends ChatCommandHandler {
         const name = cached.displayname.replaceAll(/§\w/g, '').replaceAll('[Lvl {LVL}] ', '')
         const time = Duration.seconds(recipe.duration)
         const finishTime =
-          slot.startTime + time.toMilliseconds() * (1 - quickForgeReduction / 100) + slot.processTimeModifier
+          slot.startTime + time.toMilliseconds() * (1 - quickForgeReduction / 100) + (slot.processTimeModifier ?? 0)
 
         if (finishTime > currentTime) {
           parts.push(`${name} ${formatTime(finishTime - currentTime)}`)


### PR DESCRIPTION
processTimeModifier does not seem to exist in the API response when Cole is not the mayor or minister. Without this fallback, all forge items are marked as complete.