### PR TITLE
refactor(commands): change magical power to accessory power for !mp

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -19,6 +19,7 @@ A shorter version can also be used: `!- rtca`
 | ---------------- | ---------------------------------------------------------------------------------- |
 | `67`             | It is 67!                                                                          |
 | `8ball`          | Returns a basic 8 ball response                                                    |
+| `accessorypower` | Returns a player's highest recorded SkyBlock Accessory Power                       |
 | `agatha`         | Returns a player's Agatha and foraging personal bests                              |
 | `age`            | Returns the day someone first logged on to Hypixel                                 |
 | `airstrike`      | Mute a specific person to annoy them                                               |
@@ -79,7 +80,6 @@ A shorter version can also be used: `!- rtca`
 | `kuudra`         | Returns a player's kuudra runs                                                     |
 | `level`          | Returns a player's SkyBlock level                                                  |
 | `list`           | List online members in a guild                                                     |
-| `magicalpower`   | Returns a player's highest recorded SkyBlock Magical Power                         |
 | `mayor`          | Show current Hypixel SkyBlock mayor and minister                                   |
 | `megawalls`      | Returns a player's Mega Walls stats                                                |
 | `mguild`         | Check multiple players' guilds, if any in one                                      |

--- a/src/instance/commands/commands-instance.ts
+++ b/src/instance/commands/commands-instance.ts
@@ -131,6 +131,7 @@ export class CommandsInstance extends Instance implements DisplayableInstance {
     this.cooldownHandler = new CommandsCooldownHandler(this.application)
 
     const commandsToAdd = [
+      new AccessoryPower(),
       new Agatha(),
       new Age(),
       new Airstrike(),
@@ -193,7 +194,6 @@ export class CommandsInstance extends Instance implements DisplayableInstance {
       new Kuudra(),
       new Level(),
       new List(),
-      new AccessoryPower(),
       new Mayor(),
       new Megawalls(),
       new Mineshafts(),

--- a/src/instance/commands/commands-instance.ts
+++ b/src/instance/commands/commands-instance.ts
@@ -15,6 +15,7 @@ import { CommandsCooldownHandler } from './commands-cooldown-handler'
 import { canOnlyUseIngame } from './common/utility'
 import Command67 from './triggers/67'
 import EightBallCommand from './triggers/8ball.js'
+import AccessoryPower from './triggers/accessorypower.js'
 import Agatha from './triggers/agatha.js'
 import Age from './triggers/age.js'
 import Airstrike from './triggers/airstrike'
@@ -74,7 +75,6 @@ import Karma from './triggers/karma.js'
 import Kuudra from './triggers/kuudra.js'
 import Level from './triggers/level.js'
 import List from './triggers/list.js'
-import MagicalPower from './triggers/magicalpower.js'
 import Mayor from './triggers/mayor.js'
 import Megawalls from './triggers/megawalls'
 import Mineshafts from './triggers/mineshafts.js'
@@ -193,7 +193,7 @@ export class CommandsInstance extends Instance implements DisplayableInstance {
       new Kuudra(),
       new Level(),
       new List(),
-      new MagicalPower(),
+      new AccessoryPower(),
       new Mayor(),
       new Megawalls(),
       new Mineshafts(),

--- a/src/instance/commands/triggers/accessorypower.ts
+++ b/src/instance/commands/triggers/accessorypower.ts
@@ -2,19 +2,19 @@ import { parse } from 'prismarine-nbt'
 
 import type { ChatCommandContext } from '../../../common/commands.js'
 import { ChatCommandHandler } from '../../../common/commands.js'
-import type { SkyblockMember } from '../../../core/hypixel/hypixel-skyblock'
+import type { SkyblockMember } from '../../../core/hypixel/hypixel-skyblock.js'
 import {
   getSelectedSkyblockProfile,
   getUuidIfExists,
   playerNeverPlayedSkyblock,
   usernameNotExists
-} from '../common/utility'
+} from '../common/utility.js'
 
-export default class MagicalPower extends ChatCommandHandler {
+export default class AccessoryPower extends ChatCommandHandler {
   constructor() {
     super({
-      triggers: ['magicalpower', 'mp', 'power', 'accessories', 'acc', 'talisman', 'talismans', 'talismen'],
-      description: "Returns a player's highest recorded SkyBlock Magical Power",
+      triggers: ['accessorypower', 'ap', 'power', 'accessories', 'acc', 'talisman', 'talismans', 'talismen', 'mp'],
+      description: "Returns a player's highest recorded SkyBlock Accessory Power",
       example: `mp %s`
     })
   }
@@ -28,13 +28,13 @@ export default class MagicalPower extends ChatCommandHandler {
     const selectedProfile = await getSelectedSkyblockProfile(context.app.hypixelApi, uuid)
     if (!selectedProfile) return playerNeverPlayedSkyblock(context, givenUsername)
 
-    const magicalPower = selectedProfile.accessory_bag_storage?.highest_magical_power ?? 0
+    const highestAccessoryPower = selectedProfile.accessory_bag_storage?.highest_magical_power ?? 0
     const stone = selectedProfile.accessory_bag_storage?.selected_power ?? '(none)'
     const enrichments = await this.getEnrichments(selectedProfile)
     const tuning = selectedProfile.accessory_bag_storage?.tuning.slot_0
 
     let result = `${givenUsername}:`
-    result += ` MP ${magicalPower}`
+    result += ` Highest AP ${highestAccessoryPower}`
     result += ` | Stone: ${stone}`
 
     result += ` | Tuning: `
@@ -81,10 +81,7 @@ export default class MagicalPower extends ChatCommandHandler {
     for (const slot of slots) {
       if (!('tag' in slot)) continue
 
-      const attributes = slot.tag.value.ExtraAttributes?.value
-      if (!attributes) continue
-
-      const enrichment = attributes.talisman_enrichment?.value
+      const enrichment = slot.tag.ExtraAttributes?.talisman_enrichment
       if (!enrichment) continue
 
       let type = result.find((entry) => entry.name === enrichment)
@@ -105,17 +102,11 @@ export default class MagicalPower extends ChatCommandHandler {
 type InventorySlot = InventoryItemSlot | Record<never, never>
 
 interface InventoryItemSlot {
-  id: { value: number }
-  count: { value: number }
-  tag: { value: ItemData }
+  id: number
+  count: number
+  tag: {
+    ExtraAttributes?: {
+      talisman_enrichment?: string
+    }
+  }
 }
-
-interface ItemData {
-  ExtraAttributes?: { value: SkyblockItemAttributes }
-}
-
-interface SkyblockItemAttributes {
-  talisman_enrichment?: { value: string }
-}
-
-/* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
The [latest Hypixel update](https://hypixel.net/threads/hypixel-skyblock-0-26-1-new-player-improvements-harvest-feast-changes-healing-revamp-and-more.6127383/) renames magical power to accessory power with the purpose of making it easier for new players to understand where magical power comes from and how it works. (as far as I know)

"mp" is still a trigger for this command for those who prefer it.

Additionally, some sections of code have been shortened and simplified.