### PR TITLE
fix(cmds): handle no assigned tuning points and use hyphens as separators in !ap

### DIFF
--- a/src/instance/commands/triggers/accessorypower.ts
+++ b/src/instance/commands/triggers/accessorypower.ts
@@ -37,8 +37,8 @@ export default class AccessoryPower extends ChatCommandHandler {
 
     let result = `${givenUsername}:`
     result += ` Highest AP ${highestAccessoryPower}`
-    result += ` | Stone: ${stone}`
-    result += ` | Tuning: `
+    result += ` - Stone: ${stone}`
+    result += ` - Tuning: `
 
     const noTunings = '(none)'
     if (tuning) {
@@ -56,7 +56,7 @@ export default class AccessoryPower extends ChatCommandHandler {
       result += noTunings
     }
 
-    result += ` | Enrich: `
+    result += ` - Enrich: `
     if (enrichments.length === 0) result += `(none)`
     else {
       const formatted: string[] = []

--- a/src/instance/commands/triggers/accessorypower.ts
+++ b/src/instance/commands/triggers/accessorypower.ts
@@ -40,12 +40,12 @@ export default class AccessoryPower extends ChatCommandHandler {
     result += ` - Stone: ${stone}`
     result += ` - Tuning: `
 
-    const noTunings = '(none)'
+    const noValue = '(none)'
     if (tuning) {
       const entries = Object.entries(tuning).filter(([, value]) => value > 0)
 
       if (entries.length === 0) {
-        result += noTunings
+        result += noValue
       } else {
         entries.sort(([, a], [, b]) => b - a)
         for (const [key, value] of entries) {
@@ -53,11 +53,11 @@ export default class AccessoryPower extends ChatCommandHandler {
         }
       }
     } else {
-      result += noTunings
+      result += noValue
     }
 
     result += ` - Enrich: `
-    if (enrichments.length === 0) result += `(none)`
+    if (enrichments.length === 0) result += noValue
     else {
       const formatted: string[] = []
       for (const enrichment of enrichments) {

--- a/src/instance/commands/triggers/accessorypower.ts
+++ b/src/instance/commands/triggers/accessorypower.ts
@@ -30,8 +30,10 @@ export default class AccessoryPower extends ChatCommandHandler {
     const selectedProfile = await getSelectedSkyblockProfile(context.app.hypixelApi, uuid)
     if (!selectedProfile) return playerNeverPlayedSkyblock(context, givenUsername)
 
+    const noValue = '(none)'
+
     const highestAccessoryPower = selectedProfile.accessory_bag_storage?.highest_magical_power ?? 0
-    const stone = selectedProfile.accessory_bag_storage?.selected_power ?? '(none)'
+    const stone = selectedProfile.accessory_bag_storage?.selected_power ?? noValue
     const enrichments = await this.getEnrichments(selectedProfile)
     const tuning = selectedProfile.accessory_bag_storage?.tuning.slot_0
 
@@ -40,7 +42,6 @@ export default class AccessoryPower extends ChatCommandHandler {
     result += ` - Stone: ${stone}`
     result += ` - Tuning: `
 
-    const noValue = '(none)'
     if (tuning) {
       const entries = Object.entries(tuning).filter(([, value]) => value > 0)
 

--- a/src/instance/commands/triggers/accessorypower.ts
+++ b/src/instance/commands/triggers/accessorypower.ts
@@ -38,16 +38,22 @@ export default class AccessoryPower extends ChatCommandHandler {
     let result = `${givenUsername}:`
     result += ` Highest AP ${highestAccessoryPower}`
     result += ` | Stone: ${stone}`
-
     result += ` | Tuning: `
+
+    const noTunings = '(none)'
     if (tuning) {
       const entries = Object.entries(tuning).filter(([, value]) => value > 0)
-      entries.sort(([, a], [, b]) => b - a)
-      for (const [key, value] of entries) {
-        result += `${value.toLocaleString('en-US')}${this.translatePower(key)}`
+
+      if (entries.length === 0) {
+        result += noTunings
+      } else {
+        entries.sort(([, a], [, b]) => b - a)
+        for (const [key, value] of entries) {
+          result += `${value.toLocaleString('en-US')}${this.translatePower(key)}`
+        }
       }
     } else {
-      result += '(none)'
+      result += noTunings
     }
 
     result += ` | Enrich: `


### PR DESCRIPTION
Previously, if `tuning` existed but no tuning points were assigned, the result would be `Tuning: `. The code now checks if 0 tuning points are assigned and returns `Tuning: (none)`.